### PR TITLE
Add support for parsing soap:Fault in error responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,11 +6,18 @@ version = 3
 name = "ews"
 version = "0.1.0"
 dependencies = [
+ "log",
  "quick-xml",
  "serde",
  "thiserror",
  "xml_struct",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+log = { version = "0.4.21", features = ["std"] }
 quick-xml = { version = "0.31.0", features = ["serde", "serialize"] }
 serde = { version = "1.0.196", features = ["derive"] }
 thiserror = "1.0.57"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ pub enum Error {
     #[error("unexpected response body")]
     UnexpectedResponse(Vec<u8>),
 
+    // The `Fault` is boxed so as to keep the in-memory size of the enum itself
+    // relatively low.
     #[error("a fault occurred in the request")]
     RequestFault(Box<soap::Fault>),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,12 @@ pub enum Error {
     #[error("failed to deserialize structure from XML")]
     Deserialize(#[from] quick_xml::DeError),
 
-    #[error("error manipulating XML data")]
-    Xml(#[from] quick_xml::Error),
+    #[error("invalid XML document")]
+    InvalidXml(#[from] quick_xml::Error),
+
+    #[error("unexpected response body")]
+    UnexpectedResponse(Vec<u8>),
+
+    #[error("a fault occurred in the request")]
+    RequestFault(Box<soap::Fault>),
 }

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -35,20 +35,42 @@ pub struct ItemShape {
 #[derive(Debug, Default, XmlSerialize)]
 #[xml_struct(text)]
 pub enum BaseShape {
+    /// Only the IDs of any items or folders returned.
     IdOnly,
 
+    /// The default set of properties for the relevant item or folder.
+    ///
+    /// The properties returned are dependent on the type of item or folder. See
+    /// the EWS documentation for details.
     #[default]
     Default,
 
+    /// All properties of an item or folder.
     AllProperties,
 }
 
-/// Attribute to a response message describing a response status.
+/// The success/failure status of an operation.
 #[derive(Debug, Deserialize, PartialEq)]
 pub enum ResponseClass {
     Success,
     Warning,
     Error,
+}
+
+/// An error code describing the error encountered in processing a request, if
+/// any.
+///
+/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/responsecode>
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct ResponseCode(pub String);
+
+impl<T> From<T> for ResponseCode
+where
+    T: ToString,
+{
+    fn from(value: T) -> Self {
+        Self(value.to_string())
+    }
 }
 
 /// An identifier for a remote folder.
@@ -159,4 +181,23 @@ pub enum Folder {
         total_count: Option<u32>,
         child_folder_count: Option<u32>,
     },
+}
+
+/// Structured data for diagnosing or responding to an EWS error.
+///
+/// Because the possible contents of this field are not documented, any XML
+/// contained in the field is provided as text for debugging purposes. Known
+/// fields which are relevant for programmatic error responses should be
+/// provided as additional fields of this structure.
+///
+/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/messagexml>
+#[derive(Debug, PartialEq)]
+#[non_exhaustive]
+pub struct MessageXml {
+    /// A text representation of the contents of the field.
+    pub content: String,
+
+    /// The duration in milliseconds to wait before making additional requests
+    /// if the server is throttling operations.
+    pub back_off_milliseconds: Option<usize>,
 }

--- a/src/types/soap.rs
+++ b/src/types/soap.rs
@@ -462,7 +462,7 @@ mod tests {
     }
 
     #[test]
-    fn deserialie_envelope_with_server_busy_fault() {
+    fn deserialize_envelope_with_server_busy_fault() {
         // This XML is contrived based on what's known of the shape of
         // `ErrorServerBusy` responses. It should be replaced when we have
         // real-life examples.

--- a/src/types/soap.rs
+++ b/src/types/soap.rs
@@ -4,7 +4,7 @@
 
 use quick_xml::{
     events::{BytesDecl, BytesEnd, BytesStart, Event},
-    Writer,
+    Reader, Writer,
 };
 use serde::Deserialize;
 use xml_struct::XmlSerialize;
@@ -51,7 +51,7 @@ where
     B: for<'de> Deserialize<'de>,
 {
     /// Populates an [`Envelope`] from raw XML.
-    pub fn from_xml_document(document: &str) -> Result<Self, Error> {
+    pub fn from_xml_document(document: &[u8]) -> Result<Self, Error> {
         #[derive(Deserialize)]
         #[serde(rename_all = "PascalCase")]
         struct DummyEnvelope<T> {
@@ -64,10 +64,322 @@ where
             inner: T,
         }
 
-        let envelope: DummyEnvelope<B> = quick_xml::de::from_str(document)?;
+        let fault = extract_maybe_fault(document)?;
+        if let Some(fault) = fault {
+            return Err(Error::RequestFault(Box::new(fault)));
+        }
+
+        let envelope: DummyEnvelope<B> = quick_xml::de::from_reader(document)?;
 
         Ok(Envelope {
             body: envelope.body.inner,
         })
+    }
+}
+
+fn extract_maybe_fault(document: &[u8]) -> Result<Option<Fault>, Error> {
+    let mut reader = TargetedReader::from_bytes(document);
+
+    let mut envelope_reader = reader
+        .maybe_get_subreader_for_tag("Envelope")?
+        .ok_or_else(|| unexpected_response(document))?;
+    let mut body_reader = envelope_reader
+        .maybe_get_subreader_for_tag("Body")?
+        .ok_or_else(|| unexpected_response(document))?;
+
+    let fault_reader = body_reader.maybe_get_subreader_for_tag("Fault")?;
+    let fault = if let Some(mut reader) = fault_reader {
+        let mut fault_code = None;
+        let mut fault_string = None;
+        let mut fault_actor = None;
+        let mut detail = None;
+
+        while let Some((name, subreader)) = reader.maybe_get_next_subreader()? {
+            match name.as_slice() {
+                b"faultcode" => {
+                    fault_code.replace(subreader.to_string()?);
+                }
+
+                b"faultstring" => {
+                    fault_string.replace(subreader.to_string()?);
+                }
+
+                b"faultactor" => {
+                    fault_actor.replace(subreader.to_string()?);
+                }
+
+                b"detail" => {
+                    detail.replace(parse_detail_field(subreader)?);
+                }
+
+                _ => {
+                    // This implies that Microsoft is breaking the SOAP spec. We
+                    // don't want to error, but we should log anyhow.
+                    log::warn!(
+                        "encountered unexpected element {} in soap:Fault",
+                        subreader.reader.decoder().decode(&name)?
+                    )
+                }
+            }
+        }
+
+        let fault_code = fault_code.ok_or_else(|| unexpected_response(document))?;
+        let fault_string = fault_string.ok_or_else(|| unexpected_response(document))?;
+
+        Some(Fault {
+            fault_code,
+            fault_string,
+            fault_actor,
+            detail,
+        })
+    } else {
+        None
+    };
+
+    Ok(fault)
+}
+
+fn parse_detail_field(mut reader: TargetedReader) -> Result<FaultDetail, Error> {
+    let mut detail = FaultDetail::default();
+
+    while let Some((name, subreader)) = reader.maybe_get_next_subreader()? {
+        match name.as_slice() {
+            b"ResponseCode" => {
+                detail.response_code.replace(subreader.to_string()?);
+            }
+
+            b"Message" => {
+                detail.message.replace(subreader.to_string()?);
+            }
+
+            b"MessageXml" => {
+                detail.message_xml.replace(parse_message_xml(subreader)?);
+            }
+
+            _ => {
+                // If we've already stored a copy of the full content, we don't
+                // need to replace it.
+                if detail.content.is_none() {
+                    detail.content.replace(reader.to_string()?);
+                }
+            }
+        }
+    }
+
+    Ok(detail)
+}
+
+fn parse_message_xml(mut reader: TargetedReader) -> Result<MessageXml, Error> {
+    let back_off_milliseconds = loop {
+        match reader.reader.read_event()? {
+            Event::Start(start) => {
+                if start.local_name().as_ref() == b"Value" {
+                    let is_back_off = start.attributes().any(|attr_result| match attr_result {
+                        Ok(attr) => {
+                            attr.key.local_name().as_ref() == b"Name"
+                                && attr.value.as_ref() == b"BackOffMilliseconds"
+                        }
+                        Err(_) => false,
+                    });
+
+                    if is_back_off {
+                        let text = reader.reader.read_text(start.name())?;
+                        if let Ok(value) = text.parse::<usize>() {
+                            break Some(value);
+                        }
+                    }
+                }
+            }
+
+            Event::Eof => break None,
+
+            _ => continue,
+        }
+    };
+
+    Ok(MessageXml {
+        content: reader.to_string()?,
+        back_off_milliseconds,
+    })
+}
+
+fn unexpected_response(document: &[u8]) -> Error {
+    Error::UnexpectedResponse(Vec::from(document))
+}
+
+struct TargetedReader<'content> {
+    reader: Reader<&'content [u8]>,
+    content: &'content [u8],
+}
+
+impl<'content> TargetedReader<'content> {
+    fn from_bytes(content: &'content [u8]) -> Self {
+        Self {
+            reader: Reader::from_reader(content),
+            content,
+        }
+    }
+
+    fn maybe_get_subreader_for_tag(&mut self, local_name: &str) -> Result<Option<Self>, Error> {
+        loop {
+            match self.reader.read_event()? {
+                Event::Start(start) => {
+                    if start.local_name().as_ref() == local_name.as_bytes() {
+                        return self.get_subreader_for_start(&start).map(Some);
+                    }
+                }
+
+                Event::Eof => break,
+
+                _ => continue,
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn maybe_get_next_subreader(&mut self) -> Result<Option<(Vec<u8>, Self)>, Error> {
+        loop {
+            match self.reader.read_event()? {
+                Event::Start(start) => {
+                    let reader = self.get_subreader_for_start(&start)?;
+                    let local_name = start.local_name();
+
+                    return Ok(Some((local_name.as_ref().to_owned(), reader)));
+                }
+
+                Event::Eof => break,
+
+                _ => continue,
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn get_subreader_for_start(&mut self, start: &BytesStart<'content>) -> Result<Self, Error> {
+        let span = self.reader.read_to_end(start.name())?;
+        let content = &self.content[span];
+
+        // Notably, in doing this, we throw away any encoding information we may
+        // have had from the original reader. However, Microsoft _appears_ to
+        // send all responses as UTF-8. We'll encounter bigger problems
+        // elsewhere if we run into a non-UTF-8 document, most notably that we
+        // currently don't enable the `encoding` feature for quick-xml.
+        return Ok(Self::from_bytes(content));
+    }
+
+    fn to_string(&self) -> Result<String, Error> {
+        Ok(self.reader.decoder().decode(self.content)?.into_owned())
+    }
+}
+
+///
+#[derive(Debug, PartialEq)]
+pub struct Fault {
+    /// An error code indicating the fault in the original request.
+    // While `faultcode` is defined in the SOAP spec as a `QName`, we avoid
+    // using `quick_xml::name::QName` as it borrows from the input and does not
+    // allow for containing a string representation. We could use the `QName`
+    // type to parse the contents of the field and store them in our own type if
+    // we found value in this field beyond debug output.
+    pub fault_code: String,
+
+    ///
+    pub fault_string: String,
+    pub fault_actor: Option<String>,
+    pub detail: Option<FaultDetail>,
+}
+
+#[derive(Debug, Default, PartialEq)]
+#[non_exhaustive]
+pub struct FaultDetail {
+    pub response_code: Option<String>,
+    pub message: Option<String>,
+    pub message_xml: Option<MessageXml>,
+    pub content: Option<String>,
+}
+
+#[derive(Debug, PartialEq)]
+#[non_exhaustive]
+pub struct MessageXml {
+    pub content: String,
+    pub back_off_milliseconds: Option<usize>,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Error;
+
+    use super::Envelope;
+
+    #[test]
+    fn envelope_with_schema_fault() {
+        let xml = r#"<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Body><s:Fault><faultcode xmlns:a="http://schemas.microsoft.com/exchange/services/2006/types">a:ErrorSchemaValidation</faultcode><faultstring xml:lang="en-US">The request failed schema validation: The 'Id' attribute is invalid - The value 'invalidparentid' is invalid according to its datatype 'http://schemas.microsoft.com/exchange/services/2006/types:DistinguishedFolderIdNameType' - The Enumeration constraint failed.</faultstring><detail><e:ResponseCode xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">ErrorSchemaValidation</e:ResponseCode><e:Message xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">The request failed schema validation.</e:Message><t:MessageXml xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><t:LineNumber>2</t:LineNumber><t:LinePosition>630</t:LinePosition><t:Violation>The 'Id' attribute is invalid - The value 'invalidparentid' is invalid according to its datatype 'http://schemas.microsoft.com/exchange/services/2006/types:DistinguishedFolderIdNameType' - The Enumeration constraint failed.</t:Violation></t:MessageXml></detail></s:Fault></s:Body></s:Envelope>"#;
+        let err = <Envelope<()>>::from_xml_document(xml.as_bytes())
+            .expect_err("should return error when body contains fault");
+
+        if let Error::RequestFault(fault) = err {
+            assert_eq!(
+                fault.fault_code, "a:ErrorSchemaValidation",
+                "fault code should match original document"
+            );
+            assert_eq!(fault.fault_string, "The request failed schema validation: The 'Id' attribute is invalid - The value 'invalidparentid' is invalid according to its datatype 'http://schemas.microsoft.com/exchange/services/2006/types:DistinguishedFolderIdNameType' - The Enumeration constraint failed.", "fault string should match original document");
+            assert!(
+                fault.fault_actor.is_none(),
+                "fault actor should not be present"
+            );
+
+            let detail = fault.detail.expect("fault detail should be present");
+            assert_eq!(
+                detail.response_code,
+                Some("ErrorSchemaValidation".to_string()),
+                "response code should match original document"
+            );
+            assert_eq!(
+                detail.message,
+                Some("The request failed schema validation.".to_string()),
+                "error message should match original document"
+            );
+
+            let message_xml = detail.message_xml.expect("message XML should be present");
+            assert_eq!(&message_xml.content, "<t:LineNumber>2</t:LineNumber><t:LinePosition>630</t:LinePosition><t:Violation>The 'Id' attribute is invalid - The value 'invalidparentid' is invalid according to its datatype 'http://schemas.microsoft.com/exchange/services/2006/types:DistinguishedFolderIdNameType' - The Enumeration constraint failed.</t:Violation>", "message XML content should contain full body of MessageXml tag");
+            assert!(
+                message_xml.back_off_milliseconds.is_none(),
+                "back off milliseconds should not be present"
+            );
+        } else {
+            panic!("error should be request fault");
+        }
+    }
+
+    #[test]
+    fn envelope_with_server_busy_fault() {
+        let xml = r#"<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Body><s:Fault><faultcode xmlns:a="http://schemas.microsoft.com/exchange/services/2006/types">a:ErrorServerBusy</faultcode><faultstring xml:lang="en-US">I made this up because I don't have real testing data. 🙃</faultstring><detail><e:ResponseCode xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">ErrorServerBusy</e:ResponseCode><e:Message xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">Who really knows?</e:Message><t:MessageXml xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><t:Value Name="BackOffMilliseconds">25</t:Value></t:MessageXml></detail></s:Fault></s:Body></s:Envelope>"#;
+        let err = <Envelope<()>>::from_xml_document(xml.as_bytes())
+            .expect_err("should return error when body contains fault");
+
+        if let Error::RequestFault(fault) = err {
+            assert_eq!(
+                fault.fault_code, "a:ErrorServerBusy",
+                "fault code should match original document"
+            );
+            assert!(
+                fault.fault_actor.is_none(),
+                "fault actor should not be present"
+            );
+
+            let detail = fault.detail.expect("fault detail should be present");
+            assert_eq!(
+                detail.response_code,
+                Some("ErrorServerBusy".to_string()),
+                "response code should match original document"
+            );
+
+            let message_xml = detail.message_xml.expect("message XML should be present");
+            assert_eq!(message_xml.back_off_milliseconds, Some(25));
+        } else {
+            panic!("error should be request fault");
+        }
     }
 }


### PR DESCRIPTION
Exchange will return a `soap:Fault` when there is an error at the request level (rather than at the operation level). We want to return this as an error which can be inspected by the consumer.