### PR TITLE
Use custom {de,}serialization for operation/response envelopes

### DIFF
--- a/src/types/get_folder.rs
+++ b/src/types/get_folder.rs
@@ -6,8 +6,8 @@ use serde::Deserialize;
 use xml_struct::XmlSerialize;
 
 use crate::{
-    types::sealed::EnvelopeBodyContents, BaseFolderId, Folder, FolderShape, Operation, OperationResponse,
-    ResponseClass, MESSAGES_NS_URI,
+    types::sealed::EnvelopeBodyContents, BaseFolderId, Folder, FolderShape, Operation,
+    OperationResponse, ResponseClass, MESSAGES_NS_URI,
 };
 
 /// A request to get information on one or more folders.

--- a/src/types/get_folder.rs
+++ b/src/types/get_folder.rs
@@ -6,7 +6,8 @@ use serde::Deserialize;
 use xml_struct::XmlSerialize;
 
 use crate::{
-    BaseFolderId, Folder, FolderShape, Operation, OperationResponse, ResponseClass, MESSAGES_NS_URI,
+    types::sealed::NamedStructure, BaseFolderId, Folder, FolderShape, Operation, OperationResponse,
+    ResponseClass, MESSAGES_NS_URI,
 };
 
 /// A request to get information on one or more folders.
@@ -21,7 +22,9 @@ pub struct GetFolder {
 
 impl Operation for GetFolder {
     type Response = GetFolderResponse;
+}
 
+impl NamedStructure for GetFolder {
     fn name() -> &'static str {
         "GetFolder"
     }
@@ -36,7 +39,9 @@ pub struct GetFolderResponse {
     pub response_messages: ResponseMessages,
 }
 
-impl OperationResponse for GetFolderResponse {
+impl OperationResponse for GetFolderResponse {}
+
+impl NamedStructure for GetFolderResponse {
     fn name() -> &'static str {
         "GetFolderResponse"
     }

--- a/src/types/get_folder.rs
+++ b/src/types/get_folder.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use xml_struct::XmlSerialize;
 
 use crate::{
-    types::sealed::NamedStructure, BaseFolderId, Folder, FolderShape, Operation, OperationResponse,
+    types::sealed::EnvelopeBodyContents, BaseFolderId, Folder, FolderShape, Operation, OperationResponse,
     ResponseClass, MESSAGES_NS_URI,
 };
 
@@ -24,7 +24,7 @@ impl Operation for GetFolder {
     type Response = GetFolderResponse;
 }
 
-impl NamedStructure for GetFolder {
+impl EnvelopeBodyContents for GetFolder {
     fn name() -> &'static str {
         "GetFolder"
     }
@@ -41,7 +41,7 @@ pub struct GetFolderResponse {
 
 impl OperationResponse for GetFolderResponse {}
 
-impl NamedStructure for GetFolderResponse {
+impl EnvelopeBodyContents for GetFolderResponse {
     fn name() -> &'static str {
         "GetFolderResponse"
     }

--- a/src/types/get_folder.rs
+++ b/src/types/get_folder.rs
@@ -16,7 +16,11 @@ use crate::{
 #[derive(Debug, XmlSerialize)]
 #[xml_struct(default_ns = MESSAGES_NS_URI)]
 pub struct GetFolder {
+    /// A description of the information to be included in the response for each
+    /// retrieved folder.
     pub folder_shape: FolderShape,
+
+    /// A list of IDs for which to retrieve folder information.
     pub folder_ids: Vec<BaseFolderId>,
 }
 
@@ -62,8 +66,11 @@ pub struct ResponseMessages {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct GetFolderResponseMessage {
+    /// The success value of the corresponding request.
     #[serde(rename = "@ResponseClass")]
     pub response_class: ResponseClass,
+
+    /// A collection of the retrieved folders.
     pub folders: Folders,
 }
 

--- a/src/types/get_folder.rs
+++ b/src/types/get_folder.rs
@@ -5,18 +5,29 @@
 use serde::Deserialize;
 use xml_struct::XmlSerialize;
 
-use crate::{BaseFolderId, Folder, FolderShape, ResponseClass};
+use crate::{
+    BaseFolderId, Folder, FolderShape, Operation, OperationResponse, ResponseClass, MESSAGES_NS_URI,
+};
 
-/// The request to get one or more folder(s).
+/// A request to get information on one or more folders.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/getfolder>
 #[derive(Debug, XmlSerialize)]
+#[xml_struct(default_ns = MESSAGES_NS_URI)]
 pub struct GetFolder {
     pub folder_shape: FolderShape,
     pub folder_ids: Vec<BaseFolderId>,
 }
 
-/// The response to a GetFolder request.
+impl Operation for GetFolder {
+    type Response = GetFolderResponse;
+
+    fn name() -> &'static str {
+        "GetFolder"
+    }
+}
+
+/// A response to a [`GetFolder`] request.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/getfolderresponse>
 #[derive(Debug, Deserialize)]
@@ -25,14 +36,22 @@ pub struct GetFolderResponse {
     pub response_messages: ResponseMessages,
 }
 
-/// A collection of response messages from a GetFolder response.
+impl OperationResponse for GetFolderResponse {
+    fn name() -> &'static str {
+        "GetFolderResponse"
+    }
+}
+
+/// A collection of responses for individual entities within a request.
+///
+/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/responsemessages>
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct ResponseMessages {
     pub get_folder_response_message: Vec<GetFolderResponseMessage>,
 }
 
-/// A message in a GetFolder response.
+/// A response to a request for an individual folder within a [`GetFolder`] operation.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/getfolderresponsemessage>
 #[derive(Debug, Deserialize)]
@@ -43,7 +62,7 @@ pub struct GetFolderResponseMessage {
     pub folders: Folders,
 }
 
-/// A list of folders in a GetFolder response message.
+/// A collection of information on Exchange folders.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/folders-ex15websvcsotherref>
 #[derive(Debug, Deserialize)]

--- a/src/types/operations.rs
+++ b/src/types/operations.rs
@@ -5,12 +5,14 @@
 use serde::Deserialize;
 use xml_struct::XmlSerialize;
 
-pub trait Operation: XmlSerialize {
+pub trait Operation: XmlSerialize + sealed::NamedStructure {
     type Response: OperationResponse;
-
-    fn name() -> &'static str;
 }
 
-pub trait OperationResponse: for<'de> Deserialize<'de> {
-    fn name() -> &'static str;
+pub trait OperationResponse: for<'de> Deserialize<'de> + sealed::NamedStructure {}
+
+pub(super) mod sealed {
+    pub trait NamedStructure {
+        fn name() -> &'static str;
+    }
 }

--- a/src/types/operations.rs
+++ b/src/types/operations.rs
@@ -5,14 +5,39 @@
 use serde::Deserialize;
 use xml_struct::XmlSerialize;
 
-pub trait Operation: XmlSerialize + sealed::NamedStructure {
+/// A marker trait for EWS operations.
+///
+/// Types implementing this trait may appear in requests to EWS as the operation
+/// to be performed.
+///
+/// # Usage
+///
+/// See [`Envelope`] for details.
+///
+/// [`Envelope`]: crate::soap::Envelope
+pub trait Operation: XmlSerialize + sealed::EnvelopeBodyContents {
+    /// The structure returned by EWS in response to requests containing this
+    /// operation.
     type Response: OperationResponse;
 }
 
-pub trait OperationResponse: for<'de> Deserialize<'de> + sealed::NamedStructure {}
+/// A marker trait for EWS operation responses.
+///
+/// Types implementing this trait may appear in responses from EWS after
+/// requesting an operation be performed.
+///
+/// # Usage
+///
+/// See [`Envelope`] for details.
+///
+/// [`Envelope`]: crate::soap::Envelope
+pub trait OperationResponse: for<'de> Deserialize<'de> + sealed::EnvelopeBodyContents {}
 
 pub(super) mod sealed {
-    pub trait NamedStructure {
+    /// A trait for structures which may appear in the body of a SOAP envelope.
+    pub trait EnvelopeBodyContents {
+        /// Gets the name of the element enclosing the contents of this
+        /// structure when represented in XML.
         fn name() -> &'static str;
     }
 }

--- a/src/types/operations.rs
+++ b/src/types/operations.rs
@@ -5,38 +5,12 @@
 use serde::Deserialize;
 use xml_struct::XmlSerialize;
 
-use crate::{
-    get_folder::{GetFolder, GetFolderResponse},
-    sync_folder_hierarchy::{SyncFolderHierarchy, SyncFolderHierarchyResponse},
-    MESSAGES_NS_URI,
-};
+pub trait Operation: XmlSerialize {
+    type Response: OperationResponse;
 
-/// Available EWS operations (requests) that can be performed against an
-/// Exchange server.
-#[derive(Debug, XmlSerialize)]
-#[xml_struct(default_ns = MESSAGES_NS_URI)]
-pub enum Operation {
-    /// Retrieve information regarding one or more folder(s).
-    ///
-    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/getfolder-operation#getfolder-request-example>
-    GetFolder(GetFolder),
-
-    /// Retrieve the latest changes in the folder hierarchy for this mailbox.
-    ///
-    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/syncfolderhierarchy-operation#syncfolderhierarchy-request-example>
-    SyncFolderHierarchy(SyncFolderHierarchy),
+    fn name() -> &'static str;
 }
 
-/// Responses to available operations.
-#[derive(Debug, Deserialize)]
-pub enum OperationResponse {
-    /// The response to a GetFolder operation.
-    ///
-    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/getfolder-operation#getfolder-response-example>
-    GetFolderResponse(GetFolderResponse),
-
-    /// The response to a SyncFolderHierarchy operation.
-    ///
-    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/syncfolderhierarchy-operation#successful-syncfolderhierarchy-response>
-    SyncFolderHierarchyResponse(SyncFolderHierarchyResponse),
+pub trait OperationResponse: for<'de> Deserialize<'de> {
+    fn name() -> &'static str;
 }

--- a/src/types/soap.rs
+++ b/src/types/soap.rs
@@ -14,7 +14,7 @@ use crate::{
 mod de;
 use self::de::DummyEnvelope;
 
-/// A SOAP envelope wrapping an EWS operation.
+/// A SOAP envelope containing the body of an EWS operation or response.
 ///
 /// See <https://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383494>
 #[derive(Debug)]

--- a/src/types/soap.rs
+++ b/src/types/soap.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 mod de;
-use self::de::DummyEnvelope;
+use self::de::DeserializeEnvelope;
 
 /// A SOAP envelope containing the body of an EWS operation or response.
 ///
@@ -77,7 +77,7 @@ where
             return Err(Error::RequestFault(Box::new(fault)));
         }
 
-        let envelope: DummyEnvelope<B> = quick_xml::de::from_reader(document)?;
+        let envelope: DeserializeEnvelope<B> = quick_xml::de::from_reader(document)?;
 
         Ok(Envelope {
             body: envelope.body,

--- a/src/types/soap.rs
+++ b/src/types/soap.rs
@@ -453,7 +453,7 @@ pub struct FaultDetail {
 mod tests {
     use serde::Deserialize;
 
-    use crate::{Error, OperationResponse};
+    use crate::{types::sealed::NamedStructure, Error, OperationResponse};
 
     use super::Envelope;
 
@@ -467,7 +467,9 @@ mod tests {
             _other_field: (),
         }
 
-        impl OperationResponse for SomeStruct {
+        impl OperationResponse for SomeStruct {}
+
+        impl NamedStructure for SomeStruct {
             fn name() -> &'static str {
                 "Foo"
             }
@@ -492,7 +494,9 @@ mod tests {
         #[derive(Debug, Deserialize)]
         struct Foo;
 
-        impl OperationResponse for Foo {
+        impl OperationResponse for Foo {}
+
+        impl NamedStructure for Foo {
             fn name() -> &'static str {
                 "Foo"
             }
@@ -543,7 +547,9 @@ mod tests {
         #[derive(Debug, Deserialize)]
         struct Foo;
 
-        impl OperationResponse for Foo {
+        impl OperationResponse for Foo {}
+
+        impl NamedStructure for Foo {
             fn name() -> &'static str {
                 "Foo"
             }

--- a/src/types/soap/de.rs
+++ b/src/types/soap/de.rs
@@ -8,9 +8,15 @@ use serde::{de::Visitor, Deserialize, Deserializer};
 
 use crate::OperationResponse;
 
+/// A helper for deserialization of SOAP envelopes.
+///
+/// This struct is declared separately from the more general [`Envelope`] type
+/// so that the latter can be used with types that are write-only.
+///
+/// [`Envelope`]: super::Envelope
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
-pub(super) struct DummyEnvelope<T>
+pub(super) struct DeserializeEnvelope<T>
 where
     T: OperationResponse,
 {
@@ -50,7 +56,7 @@ where
                 let expected = T::name();
                 if name.as_str() != expected {
                     return Err(serde::de::Error::custom(format_args!(
-                        "unknown field `{}`, expected {}",
+                        "unknown element `{}`, expected {}",
                         name, expected
                     )));
                 }
@@ -64,7 +70,7 @@ where
                         // The response body contained more than one element,
                         // which violates our expectations.
                         Err(serde::de::Error::custom(format_args!(
-                            "unexpected field `{}`",
+                            "unexpected element `{}`",
                             name
                         )))
                     }

--- a/src/types/soap/de.rs
+++ b/src/types/soap/de.rs
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::marker::PhantomData;
+
+use serde::{de::Visitor, Deserialize, Deserializer};
+
+use crate::OperationResponse;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub(super) struct DummyEnvelope<T>
+where
+    T: OperationResponse,
+{
+    #[serde(deserialize_with = "deserialize_body")]
+    pub body: T,
+}
+
+fn deserialize_body<'de, D, T>(body: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: OperationResponse,
+{
+    body.deserialize_map(BodyVisitor::<T>(PhantomData))
+}
+
+/// A visitor for custom name-based deserialization of operation responses.
+struct BodyVisitor<T>(PhantomData<T>);
+
+impl<'de, T> Visitor<'de> for BodyVisitor<T>
+where
+    T: OperationResponse,
+{
+    type Value = T;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("EWS operation response body")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::MapAccess<'de>,
+    {
+        match map.next_key::<String>()? {
+            Some(name) => {
+                // We expect the body of the response to contain a single
+                // element with the name of the expected operation response.
+                let expected = T::name();
+                if name.as_str() != expected {
+                    return Err(serde::de::Error::custom(format_args!(
+                        "unknown field `{}`, expected {}",
+                        name, expected
+                    )));
+                }
+
+                let value = map.next_value()?;
+
+                // To satisfy quick-xml's serde impl, we need to consume the
+                // final `None` key value in order to successfully complete.
+                match map.next_key::<String>()? {
+                    Some(name) => {
+                        // The response body contained more than one element,
+                        // which violates our expectations.
+                        Err(serde::de::Error::custom(format_args!(
+                            "unexpected field `{}`",
+                            name
+                        )))
+                    }
+                    None => Ok(value),
+                }
+            }
+            None => Err(serde::de::Error::invalid_type(
+                serde::de::Unexpected::Map,
+                &self,
+            )),
+        }
+    }
+}

--- a/src/types/sync_folder_hierarchy.rs
+++ b/src/types/sync_folder_hierarchy.rs
@@ -5,16 +5,28 @@
 use serde::Deserialize;
 use xml_struct::XmlSerialize;
 
-use crate::{BaseFolderId, Folder, FolderId, FolderShape, ResponseClass};
+use crate::{
+    BaseFolderId, Folder, FolderId, FolderShape, Operation, OperationResponse, ResponseClass,
+    MESSAGES_NS_URI,
+};
 
 /// The request for update regarding the folder hierarchy in a mailbox.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/syncfolderhierarchy>
 #[derive(Debug, XmlSerialize)]
+#[xml_struct(default_ns = MESSAGES_NS_URI)]
 pub struct SyncFolderHierarchy {
     pub folder_shape: FolderShape,
     pub sync_folder_id: Option<BaseFolderId>,
     pub sync_state: Option<String>,
+}
+
+impl Operation for SyncFolderHierarchy {
+    type Response = SyncFolderHierarchyResponse;
+
+    fn name() -> &'static str {
+        "SyncFolderHierarchy"
+    }
 }
 
 /// The response to a SyncFolderHierarchy request.
@@ -24,6 +36,12 @@ pub struct SyncFolderHierarchy {
 #[serde(rename_all = "PascalCase")]
 pub struct SyncFolderHierarchyResponse {
     pub response_messages: ResponseMessages,
+}
+
+impl OperationResponse for SyncFolderHierarchyResponse {
+    fn name() -> &'static str {
+        "SyncFolderHierarchyResponse"
+    }
 }
 
 /// A collection of response messages from a SyncFolderHierarchy response.

--- a/src/types/sync_folder_hierarchy.rs
+++ b/src/types/sync_folder_hierarchy.rs
@@ -6,8 +6,8 @@ use serde::Deserialize;
 use xml_struct::XmlSerialize;
 
 use crate::{
-    BaseFolderId, Folder, FolderId, FolderShape, Operation, OperationResponse, ResponseClass,
-    MESSAGES_NS_URI,
+    types::sealed::NamedStructure, BaseFolderId, Folder, FolderId, FolderShape, Operation,
+    OperationResponse, ResponseClass, MESSAGES_NS_URI,
 };
 
 /// The request for update regarding the folder hierarchy in a mailbox.
@@ -23,7 +23,9 @@ pub struct SyncFolderHierarchy {
 
 impl Operation for SyncFolderHierarchy {
     type Response = SyncFolderHierarchyResponse;
+}
 
+impl NamedStructure for SyncFolderHierarchy {
     fn name() -> &'static str {
         "SyncFolderHierarchy"
     }
@@ -38,7 +40,9 @@ pub struct SyncFolderHierarchyResponse {
     pub response_messages: ResponseMessages,
 }
 
-impl OperationResponse for SyncFolderHierarchyResponse {
+impl OperationResponse for SyncFolderHierarchyResponse {}
+
+impl NamedStructure for SyncFolderHierarchyResponse {
     fn name() -> &'static str {
         "SyncFolderHierarchyResponse"
     }

--- a/src/types/sync_folder_hierarchy.rs
+++ b/src/types/sync_folder_hierarchy.rs
@@ -130,6 +130,6 @@ pub enum Change {
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/delete-foldersync>
     Delete(
         /// The EWS ID for the deleted folder.
-        FolderId
+        FolderId,
     ),
 }

--- a/src/types/sync_folder_hierarchy.rs
+++ b/src/types/sync_folder_hierarchy.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use xml_struct::XmlSerialize;
 
 use crate::{
-    types::sealed::NamedStructure, BaseFolderId, Folder, FolderId, FolderShape, Operation,
+    types::sealed::EnvelopeBodyContents, BaseFolderId, Folder, FolderId, FolderShape, Operation,
     OperationResponse, ResponseClass, MESSAGES_NS_URI,
 };
 
@@ -25,7 +25,7 @@ impl Operation for SyncFolderHierarchy {
     type Response = SyncFolderHierarchyResponse;
 }
 
-impl NamedStructure for SyncFolderHierarchy {
+impl EnvelopeBodyContents for SyncFolderHierarchy {
     fn name() -> &'static str {
         "SyncFolderHierarchy"
     }
@@ -42,7 +42,7 @@ pub struct SyncFolderHierarchyResponse {
 
 impl OperationResponse for SyncFolderHierarchyResponse {}
 
-impl NamedStructure for SyncFolderHierarchyResponse {
+impl EnvelopeBodyContents for SyncFolderHierarchyResponse {
     fn name() -> &'static str {
         "SyncFolderHierarchyResponse"
     }

--- a/src/types/sync_folder_hierarchy.rs
+++ b/src/types/sync_folder_hierarchy.rs
@@ -10,14 +10,26 @@ use crate::{
     OperationResponse, ResponseClass, MESSAGES_NS_URI,
 };
 
-/// The request for update regarding the folder hierarchy in a mailbox.
+/// A request for a list of folders which have been created, updated, or deleted
+/// server-side.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/syncfolderhierarchy>
 #[derive(Debug, XmlSerialize)]
 #[xml_struct(default_ns = MESSAGES_NS_URI)]
 pub struct SyncFolderHierarchy {
+    /// A description of the information to be included in the response for each
+    /// changed folder.
     pub folder_shape: FolderShape,
+
+    /// The ID of the folder to sync.
     pub sync_folder_id: Option<BaseFolderId>,
+
+    /// The synchronization state after which to list changes.
+    ///
+    /// If `None`, the response will include `Create` changes for each folder
+    /// which is a descendant of the requested folder.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/syncstate-ex15websvcsotherref>
     pub sync_state: Option<String>,
 }
 
@@ -31,7 +43,7 @@ impl EnvelopeBodyContents for SyncFolderHierarchy {
     }
 }
 
-/// The response to a SyncFolderHierarchy request.
+/// A response to a [`SyncFolderHierarchy`] request.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/syncfolderhierarchyresponse>
 #[derive(Debug, Deserialize)]
@@ -48,27 +60,40 @@ impl EnvelopeBodyContents for SyncFolderHierarchyResponse {
     }
 }
 
-/// A collection of response messages from a SyncFolderHierarchy response.
+/// A collection of responses for individual entities within a request.
+///
+/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/responsemessages>
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct ResponseMessages {
     pub sync_folder_hierarchy_response_message: Vec<SyncFolderHierarchyResponseMessage>,
 }
 
-/// A message in a SyncFolderHierarchy response.
+/// A response to a request for an individual folder within a [`SyncFolderHierarchy`] operation.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/syncfolderhierarchyresponsemessage>
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct SyncFolderHierarchyResponseMessage {
+    /// The success value of the corresponding request.
     #[serde(rename = "@ResponseClass")]
     pub response_class: ResponseClass,
+
+    /// An identifier for the synchronization state following application of the
+    /// changes included in this response.
     pub sync_state: String,
+
+    /// Whether all relevant folder changes have been synchronized following
+    /// this response.
     pub includes_last_folder_in_range: bool,
+
+    /// The collection of changes between the prior synchronization state and
+    /// the one represented by this response.
     pub changes: Changes,
 }
 
-/// The changes that happened since the last folder hierachy sync.
+/// A sequentially-ordered collection of folder creations, updates, and
+/// deletions.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/changes-hierarchy>
 #[derive(Debug, Deserialize)]
@@ -77,29 +102,34 @@ pub struct Changes {
     pub inner: Vec<Change>,
 }
 
-/// A single change described in a SyncFolderHierarchy response message.
+/// A server-side change to a folder.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/changes-hierarchy>
 #[derive(Debug, Deserialize)]
 pub enum Change {
-    /// A folder to create.
+    /// A creation of a folder.
     ///
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/create-foldersync>
     Create {
+        /// The state of the folder upon creation.
         #[serde(rename = "$value")]
         folder: Folder,
     },
 
-    /// A folder to update.
+    /// An update to a folder.
     ///
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/update-foldersync>
     Update {
+        /// The updated state of the folder.
         #[serde(rename = "$value")]
         folder: Folder,
     },
 
-    /// A folder to delete.
+    /// A deletion of a folder.
     ///
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/delete-foldersync>
-    Delete(FolderId),
+    Delete(
+        /// The EWS ID for the deleted folder.
+        FolderId
+    ),
 }


### PR DESCRIPTION
This allows for creating a strongly-typed link between an operation and its associated response, rather than forcing consumers to match on enums when only a single variant is possible without error.