### PR TITLE
Add support for `SyncFolderItems` and partial support for `GetItem`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "quick-xml",
  "serde",
  "thiserror",
+ "time",
  "xml_struct",
 ]
 
@@ -21,15 +22,15 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
@@ -46,27 +47,27 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -75,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -86,22 +87,48 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
+dependencies = [
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]
@@ -113,7 +140,7 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 [[package]]
 name = "xml_struct"
 version = "0.1.0"
-source = "git+https://github.com/thunderbird/xml-struct-rs.git?rev=ace285b5848750064d4f5ad30ddc0c0bff53d8a9#ace285b5848750064d4f5ad30ddc0c0bff53d8a9"
+source = "git+https://github.com/thunderbird/xml-struct-rs.git?rev=0374b50878596a08ef9c9ac2dfcc7325b9c39b83#0374b50878596a08ef9c9ac2dfcc7325b9c39b83"
 dependencies = [
  "quick-xml",
  "thiserror",
@@ -123,7 +150,7 @@ dependencies = [
 [[package]]
 name = "xml_struct_derive"
 version = "0.1.0"
-source = "git+https://github.com/thunderbird/xml-struct-rs.git?rev=ace285b5848750064d4f5ad30ddc0c0bff53d8a9#ace285b5848750064d4f5ad30ddc0c0bff53d8a9"
+source = "git+https://github.com/thunderbird/xml-struct-rs.git?rev=0374b50878596a08ef9c9ac2dfcc7325b9c39b83#0374b50878596a08ef9c9ac2dfcc7325b9c39b83"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "log",
  "quick-xml",
  "serde",
+ "serde_path_to_error",
  "thiserror",
  "time",
  "xml_struct",
@@ -72,6 +73,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ log = { version = "0.4.21", features = ["std"] }
 quick-xml = { version = "0.31.0", features = ["serde", "serialize"] }
 serde = { version = "1.0.196", features = ["derive"] }
 thiserror = "1.0.57"
-xml_struct = { git = "https://github.com/thunderbird/xml-struct-rs.git", rev = "ace285b5848750064d4f5ad30ddc0c0bff53d8a9", version = "0.1.0" }
+time = { version = "0.3.23", features = ["parsing", "serde"] }
+xml_struct = { git = "https://github.com/thunderbird/xml-struct-rs.git", rev = "0374b50878596a08ef9c9ac2dfcc7325b9c39b83", version = "0.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 log = { version = "0.4.21", features = ["std"] }
 quick-xml = { version = "0.31.0", features = ["serde", "serialize"] }
 serde = { version = "1.0.196", features = ["derive"] }
+serde_path_to_error = "0.1.11"
 thiserror = "1.0.57"
 time = { version = "0.3.23", features = ["parsing", "serde"] }
 xml_struct = { git = "https://github.com/thunderbird/xml-struct-rs.git", rev = "0374b50878596a08ef9c9ac2dfcc7325b9c39b83", version = "0.1.0" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub enum Error {
     Serialize(#[from] xml_struct::Error),
 
     #[error("failed to deserialize structure from XML")]
-    Deserialize(#[from] quick_xml::DeError),
+    Deserialize(#[from] serde_path_to_error::Error<quick_xml::DeError>),
 
     #[error("invalid XML document")]
     InvalidXml(#[from] quick_xml::Error),

--- a/src/types.rs
+++ b/src/types.rs
@@ -10,4 +10,6 @@ pub use operations::*;
 pub mod soap;
 
 pub mod get_folder;
+pub mod get_item;
 pub mod sync_folder_hierarchy;
+pub mod sync_folder_items;

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -267,7 +267,6 @@ pub enum BaseItemId {
         #[xml_struct(attribute)]
         change_key: Option<String>,
     },
-
     // OccurrenceItemId { .. }
     // RecurringMasterItemId { .. }
 }

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -593,6 +593,8 @@ pub struct Body {
     pub is_truncated: Option<bool>,
 
     /// The content of the body.
+    // TODO: It's not immediately obvious why this tag may be empty, but it has
+    // been encountered in real world responses. Needs a closer look.
     #[serde(rename = "$text")]
     pub content: Option<String>,
 }

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -651,7 +651,6 @@ pub enum Attachment {
         ///
         /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/isinline>
         is_inline: Option<bool>,
-
         // XXX: With this field in place, parsing will fail if there is no
         // `AttachmentItem` in the response.
         // See https://github.com/tafia/quick-xml/issues/683

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -60,6 +60,7 @@ pub enum PathToElement {
     // property is fully specified by a type and either:
     // - A property set ID plus property name/ID, or
     // - A property tag.
+    // https://github.com/thunderbird/ews-rs/issues/9
     ExtendedFieldURI {
         /// A well-known identifier for a property set.
         #[xml_struct(attribute)]
@@ -98,6 +99,7 @@ pub enum PathToElement {
         /// The well-known string.
         // TODO: Adjust xml_struct to support field renaming to avoid non-snake
         // case identifiers.
+        // https://github.com/thunderbird/xml-struct-rs/issues/6
         // TODO: We could use an enum for this field. It's just large and not
         // worth typing out by hand.
         #[xml_struct(attribute)]
@@ -256,6 +258,7 @@ pub struct FolderId {
 /// An identifier for an Exchange item.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/itemids>
+// N.B.: Commented-out variants are not yet implemented.
 #[derive(Debug, XmlSerialize)]
 #[xml_struct(variant_ns_prefix = "t")]
 pub enum BaseItemId {
@@ -367,6 +370,7 @@ pub enum RealItem {
 /// An item which may appear in an item-based attachment.
 ///
 /// See [`Attachment::ItemAttachment`] for details.
+// N.B.: Commented-out variants are not yet implemented.
 #[derive(Debug, Deserialize)]
 pub enum AttachmentItem {
     // Item(Item),
@@ -522,8 +526,9 @@ pub struct Mailbox {
 /// A protocol used in routing mail.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/routingtype-emailaddress>
-#[derive(Clone, Copy, Debug, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize)]
 pub enum RoutingType {
+    #[default]
     SMTP,
     EX,
 }

--- a/src/types/get_folder.rs
+++ b/src/types/get_folder.rs
@@ -66,7 +66,8 @@ pub struct ResponseMessages {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct GetFolderResponseMessage {
-    /// The success value of the corresponding request.
+    /// The status of the corresponding request, i.e. whether it succeeded or
+    /// resulted in an error.
     #[serde(rename = "@ResponseClass")]
     pub response_class: ResponseClass,
 

--- a/src/types/get_item.rs
+++ b/src/types/get_item.rs
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use serde::Deserialize;
+use xml_struct::XmlSerialize;
+
+use crate::{
+    types::sealed::EnvelopeBodyContents, BaseItemId, ItemShape, Operation, OperationResponse,
+    RealItem, ResponseClass, ResponseCode, MESSAGES_NS_URI,
+};
+
+#[derive(Debug, XmlSerialize)]
+#[xml_struct(default_ns = MESSAGES_NS_URI)]
+pub struct GetItem {
+    pub item_shape: ItemShape,
+    pub item_ids: Vec<BaseItemId>,
+}
+
+impl Operation for GetItem {
+    type Response = GetItemResponse;
+}
+
+impl EnvelopeBodyContents for GetItem {
+    fn name() -> &'static str {
+        "GetItem"
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct GetItemResponse {
+    pub response_messages: ResponseMessages,
+}
+
+impl OperationResponse for GetItemResponse {}
+
+impl EnvelopeBodyContents for GetItemResponse {
+    fn name() -> &'static str {
+        "GetItemResponse"
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ResponseMessages {
+    pub get_item_response_message: Vec<GetItemResponseMessage>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct GetItemResponseMessage {
+    /// The success value of the corresponding request.
+    #[serde(rename = "@ResponseClass")]
+    pub response_class: ResponseClass,
+
+    pub response_code: Option<ResponseCode>,
+
+    pub message_text: Option<String>,
+
+    pub items: Items,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Items {
+    #[serde(rename = "$value")]
+    pub inner: Vec<RealItem>,
+}

--- a/src/types/get_item.rs
+++ b/src/types/get_item.rs
@@ -10,10 +10,22 @@ use crate::{
     RealItem, ResponseClass, ResponseCode, MESSAGES_NS_URI,
 };
 
+/// A request for the properties of one or more Exchange items, e.g. messages,
+/// calendar events, or contacts.
+///
+/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/getitem>
 #[derive(Debug, XmlSerialize)]
 #[xml_struct(default_ns = MESSAGES_NS_URI)]
 pub struct GetItem {
+    /// A description of the information to be included in the response for each
+    /// item.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/itemshape>
     pub item_shape: ItemShape,
+
+    /// The Exchange identifiers of the items which should be fetched.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/itemids>
     pub item_ids: Vec<BaseItemId>,
 }
 
@@ -27,6 +39,9 @@ impl EnvelopeBodyContents for GetItem {
     }
 }
 
+/// A response to a [`GetItem`] request.
+///
+/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/getitemresponse>
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct GetItemResponse {
@@ -50,7 +65,8 @@ pub struct ResponseMessages {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct GetItemResponseMessage {
-    /// The success value of the corresponding request.
+    /// The status of the corresponding request, i.e. whether it succeeded or
+    /// resulted in an error.
     #[serde(rename = "@ResponseClass")]
     pub response_class: ResponseClass,
 

--- a/src/types/soap.rs
+++ b/src/types/soap.rs
@@ -79,15 +79,11 @@ where
 
         let de = &mut quick_xml::de::Deserializer::from_reader(document);
 
-        // `serde_path_to_error` ensures that we can debug the
-        let envelope: DeserializeEnvelope<B> = match serde_path_to_error::deserialize(de) {
-            Ok(envelope) => envelope,
-            Err(err) => {
-                log::debug!("Failed to deserialize: {err:?}");
-
-                return Err(err.into_inner().into());
-            }
-        };
+        // `serde_path_to_error` ensures that we get sufficient information to
+        // debug errors in deserialization. serde's default errors only provide
+        // the immediate error with no context; this gives us a description of
+        // the context within the structure.
+        let envelope: DeserializeEnvelope<B> = serde_path_to_error::deserialize(de)?;
 
         Ok(Envelope {
             body: envelope.body,

--- a/src/types/sync_folder_hierarchy.rs
+++ b/src/types/sync_folder_hierarchy.rs
@@ -75,7 +75,8 @@ pub struct ResponseMessages {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct SyncFolderHierarchyResponseMessage {
-    /// The success value of the corresponding request.
+    /// The status of the corresponding request, i.e. whether it succeeded or
+    /// resulted in an error.
     #[serde(rename = "@ResponseClass")]
     pub response_class: ResponseClass,
 

--- a/src/types/sync_folder_items.rs
+++ b/src/types/sync_folder_items.rs
@@ -111,11 +111,13 @@ pub enum Change {
     /// A deletion of an item.
     ///
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/delete-itemsync>
+    #[serde(rename_all = "PascalCase")]
     Delete {
         /// The EWS ID for the deleted item.
         item_id: ItemId,
     },
 
+    #[serde(rename_all = "PascalCase")]
     ReadFlagChange {
         item_id: ItemId,
         is_read: bool,

--- a/src/types/sync_folder_items.rs
+++ b/src/types/sync_folder_items.rs
@@ -118,8 +118,5 @@ pub enum Change {
     },
 
     #[serde(rename_all = "PascalCase")]
-    ReadFlagChange {
-        item_id: ItemId,
-        is_read: bool,
-    },
+    ReadFlagChange { item_id: ItemId, is_read: bool },
 }

--- a/src/types/sync_folder_items.rs
+++ b/src/types/sync_folder_items.rs
@@ -1,0 +1,123 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use serde::Deserialize;
+use xml_struct::XmlSerialize;
+
+use crate::{
+    types::sealed::EnvelopeBodyContents, BaseFolderId, ItemId, ItemShape, Operation,
+    OperationResponse, RealItem, ResponseClass, MESSAGES_NS_URI,
+};
+
+#[derive(Debug, XmlSerialize)]
+#[xml_struct(default_ns = MESSAGES_NS_URI)]
+pub struct SyncFolderItems {
+    pub item_shape: ItemShape,
+    pub sync_folder_id: BaseFolderId,
+    pub sync_state: Option<String>,
+    pub ignore: Option<Ignore>,
+    pub max_changes_returned: u16,
+    pub sync_scope: Option<SyncScope>,
+}
+
+impl Operation for SyncFolderItems {
+    type Response = SyncFolderItemsResponse;
+}
+
+impl EnvelopeBodyContents for SyncFolderItems {
+    fn name() -> &'static str {
+        "SyncFolderItems"
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct SyncFolderItemsResponse {
+    pub response_messages: ResponseMessages,
+}
+
+impl OperationResponse for SyncFolderItemsResponse {}
+
+impl EnvelopeBodyContents for SyncFolderItemsResponse {
+    fn name() -> &'static str {
+        "SyncFolderItemsResponse"
+    }
+}
+
+/// A collection of responses for individual entities within a request.
+///
+/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/responsemessages>
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ResponseMessages {
+    pub sync_folder_items_response_message: Vec<SyncFolderItemsResponseMessage>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct SyncFolderItemsResponseMessage {
+    /// The success value of the corresponding request.
+    #[serde(rename = "@ResponseClass")]
+    pub response_class: ResponseClass,
+
+    pub sync_state: String,
+
+    pub includes_last_item_in_range: bool,
+
+    pub changes: Changes,
+}
+
+#[derive(Debug, XmlSerialize)]
+pub struct Ignore {
+    item_id: Vec<ItemId>,
+}
+
+#[derive(Debug, XmlSerialize)]
+pub enum SyncScope {
+    NormalItems,
+    NormalAndAssociatedItems,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Changes {
+    #[serde(default, rename = "$value")]
+    pub inner: Vec<Change>,
+}
+
+/// A server-side change to an item.
+///
+/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/changes-items>
+#[derive(Debug, Deserialize)]
+pub enum Change {
+    /// A creation of an item.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/create-itemsync>
+    Create {
+        /// The state of the item upon creation.
+        #[serde(rename = "$value")]
+        item: RealItem,
+    },
+
+    /// An update to an item.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/update-itemsync>
+    Update {
+        /// The updated state of the item.
+        #[serde(rename = "$value")]
+        item: RealItem,
+    },
+
+    /// A deletion of an item.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/delete-itemsync>
+    Delete {
+        /// The EWS ID for the deleted item.
+        item_id: ItemId,
+    },
+
+    ReadFlagChange {
+        item_id: ItemId,
+        is_read: bool,
+    },
+}

--- a/src/types/sync_folder_items.rs
+++ b/src/types/sync_folder_items.rs
@@ -73,7 +73,7 @@ pub struct Ignore {
     item_id: Vec<ItemId>,
 }
 
-#[derive(Debug, XmlSerialize)]
+#[derive(Clone, Copy, Debug, XmlSerialize)]
 pub enum SyncScope {
     NormalItems,
     NormalAndAssociatedItems,


### PR DESCRIPTION
The Item type only currently has support for Messages, so GetItem requests for non-Message items will fail during deserialization.

This is still missing a fair bit of documentation.