### PR TITLE
Support serializing Message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
 name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +127,7 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
+ "itoa",
  "serde",
  "time-core",
  "time-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "anyhow"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+
+[[package]]
 name = "ews"
 version = "0.1.0"
 dependencies = [
@@ -157,8 +163,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 [[package]]
 name = "xml_struct"
 version = "0.1.0"
-source = "git+https://github.com/thunderbird/xml-struct-rs.git?rev=24f6adb2651b5ade5bd3b7b971f64063131598ac#24f6adb2651b5ade5bd3b7b971f64063131598ac"
+source = "git+https://github.com/thunderbird/xml-struct-rs.git?rev=87723b90425d474fd29095d8b710baefd7c9b13a#87723b90425d474fd29095d8b710baefd7c9b13a"
 dependencies = [
+ "anyhow",
  "quick-xml",
  "thiserror",
  "xml_struct_derive",
@@ -167,7 +174,7 @@ dependencies = [
 [[package]]
 name = "xml_struct_derive"
 version = "0.1.0"
-source = "git+https://github.com/thunderbird/xml-struct-rs.git?rev=24f6adb2651b5ade5bd3b7b971f64063131598ac#24f6adb2651b5ade5bd3b7b971f64063131598ac"
+source = "git+https://github.com/thunderbird/xml-struct-rs.git?rev=87723b90425d474fd29095d8b710baefd7c9b13a#87723b90425d474fd29095d8b710baefd7c9b13a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 [[package]]
 name = "xml_struct"
 version = "0.1.0"
-source = "git+https://github.com/thunderbird/xml-struct-rs.git?rev=0374b50878596a08ef9c9ac2dfcc7325b9c39b83#0374b50878596a08ef9c9ac2dfcc7325b9c39b83"
+source = "git+https://github.com/thunderbird/xml-struct-rs.git?rev=24f6adb2651b5ade5bd3b7b971f64063131598ac#24f6adb2651b5ade5bd3b7b971f64063131598ac"
 dependencies = [
  "quick-xml",
  "thiserror",
@@ -167,7 +167,7 @@ dependencies = [
 [[package]]
 name = "xml_struct_derive"
 version = "0.1.0"
-source = "git+https://github.com/thunderbird/xml-struct-rs.git?rev=0374b50878596a08ef9c9ac2dfcc7325b9c39b83#0374b50878596a08ef9c9ac2dfcc7325b9c39b83"
+source = "git+https://github.com/thunderbird/xml-struct-rs.git?rev=24f6adb2651b5ade5bd3b7b971f64063131598ac#24f6adb2651b5ade5bd3b7b971f64063131598ac"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ quick-xml = { version = "0.31.0", features = ["serde", "serialize"] }
 serde = { version = "1.0.196", features = ["derive"] }
 serde_path_to_error = "0.1.11"
 thiserror = "1.0.57"
-time = { version = "0.3.23", features = ["parsing", "serde"] }
+time = { version = "0.3.23", features = ["formatting", "parsing", "serde"] }
 xml_struct = { git = "https://github.com/thunderbird/xml-struct-rs.git", rev = "0374b50878596a08ef9c9ac2dfcc7325b9c39b83", version = "0.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ serde = { version = "1.0.196", features = ["derive"] }
 serde_path_to_error = "0.1.11"
 thiserror = "1.0.57"
 time = { version = "0.3.23", features = ["formatting", "parsing", "serde"] }
-xml_struct = { git = "https://github.com/thunderbird/xml-struct-rs.git", rev = "24f6adb2651b5ade5bd3b7b971f64063131598ac", version = "0.1.0" }
+xml_struct = { git = "https://github.com/thunderbird/xml-struct-rs.git", rev = "87723b90425d474fd29095d8b710baefd7c9b13a", version = "0.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ serde = { version = "1.0.196", features = ["derive"] }
 serde_path_to_error = "0.1.11"
 thiserror = "1.0.57"
 time = { version = "0.3.23", features = ["formatting", "parsing", "serde"] }
-xml_struct = { git = "https://github.com/thunderbird/xml-struct-rs.git", rev = "0374b50878596a08ef9c9ac2dfcc7325b9c39b83", version = "0.1.0" }
+xml_struct = { git = "https://github.com/thunderbird/xml-struct-rs.git", rev = "24f6adb2651b5ade5bd3b7b971f64063131598ac", version = "0.1.0" }

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -404,7 +404,7 @@ impl XmlSerialize for DateTime {
         let time = self
             .0
             .format(&Iso8601::DEFAULT)
-            .map_err(|err| xml_struct::Error::Format(err.into()))?;
+            .map_err(|err| xml_struct::Error::Value(err.into()))?;
 
         time.serialize_child_nodes(writer)
     }


### PR DESCRIPTION
Prerequisite to support sending messages, since [`CreateItem`](https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/createitem-operation-email-message) uses the same `Message` type as `GetItem`. Note that this makes `Message::item_id` an `Option`, since we don't have an Exchange ID yet when sending.

Requires https://github.com/thunderbird/xml-struct-rs/pull/7, https://github.com/thunderbird/xml-struct-rs/pull/8 (hence CI failing)