### PR TITLE
Add types for CreateItem

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -9,6 +9,7 @@ pub use common::*;
 pub use operations::*;
 pub mod soap;
 
+pub mod create_item;
 pub mod get_folder;
 pub mod get_item;
 pub mod sync_folder_hierarchy;

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -430,78 +430,154 @@ pub struct Message {
     pub mime_content: Option<MimeContent>,
 
     /// The item's Exchange identifier.
+    #[xml_struct(ns_prefix = "t")]
     pub item_id: Option<ItemId>,
 
     /// The identifier for the containing folder.
     ///
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/parentfolderid>
+    #[xml_struct(ns_prefix = "t")]
     pub parent_folder_id: Option<FolderId>,
 
     /// The Exchange class value of the item.
     ///
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/itemclass>
+    #[xml_struct(ns_prefix = "t")]
     pub item_class: Option<String>,
 
     /// The subject of the item.
     ///
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/subject>
+    #[xml_struct(ns_prefix = "t")]
     pub subject: Option<String>,
 
+    #[xml_struct(ns_prefix = "t")]
     pub sensitivity: Option<Sensitivity>,
+
+    #[xml_struct(ns_prefix = "t")]
     pub body: Option<Body>,
+
+    #[xml_struct(ns_prefix = "t")]
     pub attachments: Option<Attachments>,
+
+    #[xml_struct(ns_prefix = "t")]
     pub date_time_received: Option<DateTime>,
+
+    #[xml_struct(ns_prefix = "t")]
     pub size: Option<usize>,
 
     /// A list of categories describing an item.
     ///
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/categories-ex15websvcsotherref>
+    #[xml_struct(ns_prefix = "t")]
     pub categories: Option<Vec<StringElement>>,
 
-    pub importance: Option<Importance>,
-    pub in_reply_to: Option<String>,
-    pub is_submitted: Option<bool>,
-    pub is_draft: Option<bool>,
-    pub is_from_me: Option<bool>,
-    pub is_resend: Option<bool>,
-    pub is_unmodified: Option<bool>,
-    pub internet_message_headers: Option<InternetMessageHeaders>,
-    pub date_time_sent: Option<DateTime>,
-    pub date_time_created: Option<DateTime>,
-    pub reminder_due_by: Option<DateTime>,
-    pub reminder_is_set: Option<bool>,
-    pub reminder_minutes_before_start: Option<usize>,
-    pub display_cc: Option<String>,
-    pub display_to: Option<String>,
-    pub has_attachments: Option<bool>,
-    pub culture: Option<String>,
-    pub sender: Option<Recipient>,
-    #[serde(default)]
-    #[serde(deserialize_with = "deserialize_recipients")]
-    pub to_recipients: Option<Vec<Recipient>>,
-    #[serde(default)]
-    #[serde(deserialize_with = "deserialize_recipients")]
-    pub cc_recipients: Option<Vec<Recipient>>,
-    #[serde(default)]
-    #[serde(deserialize_with = "deserialize_recipients")]
     #[xml_struct(ns_prefix = "t")]
-    pub bcc_recipients: Option<Vec<Recipient>>,
+    pub importance: Option<Importance>,
+
+    #[xml_struct(ns_prefix = "t")]
+    pub in_reply_to: Option<String>,
+
+    #[xml_struct(ns_prefix = "t")]
+    pub is_submitted: Option<bool>,
+
+    #[xml_struct(ns_prefix = "t")]
+    pub is_draft: Option<bool>,
+
+    #[xml_struct(ns_prefix = "t")]
+    pub is_from_me: Option<bool>,
+
+    #[xml_struct(ns_prefix = "t")]
+    pub is_resend: Option<bool>,
+
+    #[xml_struct(ns_prefix = "t")]
+    pub is_unmodified: Option<bool>,
+
+    #[xml_struct(ns_prefix = "t")]
+    pub internet_message_headers: Option<InternetMessageHeaders>,
+
+    #[xml_struct(ns_prefix = "t")]
+    pub date_time_sent: Option<DateTime>,
+
+    #[xml_struct(ns_prefix = "t")]
+    pub date_time_created: Option<DateTime>,
+
+    #[xml_struct(ns_prefix = "t")]
+    pub reminder_due_by: Option<DateTime>,
+
+    #[xml_struct(ns_prefix = "t")]
+    pub reminder_is_set: Option<bool>,
+
+    #[xml_struct(ns_prefix = "t")]
+    pub reminder_minutes_before_start: Option<usize>,
+
+    #[xml_struct(ns_prefix = "t")]
+    pub display_cc: Option<String>,
+
+    #[xml_struct(ns_prefix = "t")]
+    pub display_to: Option<String>,
+
+    #[xml_struct(ns_prefix = "t")]
+    pub has_attachments: Option<bool>,
+
+    #[xml_struct(ns_prefix = "t")]
+    pub culture: Option<String>,
+
+    #[xml_struct(ns_prefix = "t")]
+    pub sender: Option<Recipient>,
+
+    #[xml_struct(ns_prefix = "t")]
+    pub to_recipients: Option<ArrayOfRecipients>,
+
+    #[xml_struct(ns_prefix = "t")]
+    pub cc_recipients: Option<ArrayOfRecipients>,
+
+    #[xml_struct(ns_prefix = "t")]
+    pub bcc_recipients: Option<ArrayOfRecipients>,
+
+    #[xml_struct(ns_prefix = "t")]
     pub is_read_receipt_requested: Option<bool>,
+
     #[xml_struct(ns_prefix = "t")]
     pub is_delivery_receipt_requested: Option<bool>,
+
+    #[xml_struct(ns_prefix = "t")]
     pub conversation_index: Option<String>,
+
+    #[xml_struct(ns_prefix = "t")]
     pub conversation_topic: Option<String>,
+
+    #[xml_struct(ns_prefix = "t")]
     pub from: Option<Recipient>,
+
     #[xml_struct(ns_prefix = "t")]
     pub internet_message_id: Option<String>,
+
+    #[xml_struct(ns_prefix = "t")]
     pub is_read: Option<bool>,
+
+    #[xml_struct(ns_prefix = "t")]
     pub is_response_requested: Option<bool>,
+
+    #[xml_struct(ns_prefix = "t")]
     pub reply_to: Option<Recipient>,
+
+    #[xml_struct(ns_prefix = "t")]
     pub received_by: Option<Recipient>,
+
+    #[xml_struct(ns_prefix = "t")]
     pub received_representing: Option<Recipient>,
+
+    #[xml_struct(ns_prefix = "t")]
     pub last_modified_name: Option<String>,
+
+    #[xml_struct(ns_prefix = "t")]
     pub last_modified_time: Option<DateTime>,
+
+    #[xml_struct(ns_prefix = "t")]
     pub is_associated: Option<bool>,
+
+    #[xml_struct(ns_prefix = "t")]
     pub conversation_id: Option<ItemId>,
 }
 
@@ -514,6 +590,13 @@ pub struct Attachments {
     #[xml_struct(flatten)]
     pub inner: Vec<Attachment>,
 }
+
+// A newtype around a vector of `Recipient`s, that is deserialized using
+// `deserialize_recipients`.
+#[derive(Debug, Default, Deserialize, XmlSerialize)]
+pub struct ArrayOfRecipients(
+    #[serde(deserialize_with = "deserialize_recipients")] pub Vec<Recipient>,
+);
 
 /// A single mailbox.
 #[derive(Debug, Deserialize, XmlSerialize)]
@@ -528,11 +611,11 @@ pub struct Recipient {
 /// `quick-xml`'s `serde` implementation requires the presence of an
 /// intermediate type when dealing with lists, and this is not compatible with
 /// our model for serialization.
-/// 
+///
 /// We could directly deserialize into a `Vec<Mailbox>`, which would also
 /// simplify this function a bit, but this would mean using different models
 /// to represent single vs. multiple recipient(s).
-fn deserialize_recipients<'de, D>(deserializer: D) -> Result<Option<Vec<Recipient>>, D::Error>
+fn deserialize_recipients<'de, D>(deserializer: D) -> Result<Vec<Recipient>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -544,14 +627,11 @@ where
 
     let seq = MailboxSequence::deserialize(deserializer)?;
 
-    Ok(Some(
-        seq.mailbox
-            .iter()
-            .map(|mailbox| Recipient {
-                mailbox: mailbox.clone(),
-            })
-            .collect(),
-    ))
+    Ok(seq
+        .mailbox
+        .into_iter()
+        .map(|mailbox| Recipient { mailbox })
+        .collect())
 }
 
 /// A list of Internet Message Format headers.

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -278,7 +278,7 @@ pub enum BaseItemId {
 /// The unique identifier of an item.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/itemid>
-#[derive(Debug, Deserialize, XmlSerialize)]
+#[derive(Clone, Debug, Deserialize, XmlSerialize)]
 pub struct ItemId {
     #[xml_struct(attribute)]
     #[serde(rename = "@Id")]
@@ -359,11 +359,20 @@ pub enum Folder {
     },
 }
 
+/// An array of items.
+#[derive(Debug, Deserialize, XmlSerialize)]
+pub struct Items {
+    #[serde(rename = "$value", default)]
+    #[xml_struct(flatten)]
+    pub inner: Vec<RealItem>,
+}
+
 /// An item which may appear as the result of a request to read or modify an
 /// Exchange item.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/items>
 #[derive(Debug, Deserialize, XmlSerialize)]
+#[xml_struct(variant_ns_prefix = "t")]
 pub enum RealItem {
     Message(Message),
 }
@@ -413,10 +422,11 @@ impl XmlSerialize for DateTime {
 /// An email message.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/message-ex15websvcsotherref>
-#[derive(Debug, Deserialize, XmlSerialize)]
+#[derive(Default, Debug, Deserialize, XmlSerialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct Message {
     /// The MIME content of the item.
+    #[xml_struct(ns_prefix = "t")]
     pub mime_content: Option<MimeContent>,
 
     /// The item's Exchange identifier.
@@ -470,6 +480,7 @@ pub struct Message {
     pub cc_recipients: Option<ArrayOfRecipients>,
     pub bcc_recipients: Option<ArrayOfRecipients>,
     pub is_read_receipt_requested: Option<bool>,
+    #[xml_struct(ns_prefix = "t")]
     pub is_delivery_receipt_requested: Option<bool>,
     pub conversation_index: Option<String>,
     pub conversation_topic: Option<String>,

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -478,6 +478,7 @@ pub struct Message {
     pub sender: Option<SingleRecipient>,
     pub to_recipients: Option<ArrayOfRecipients>,
     pub cc_recipients: Option<ArrayOfRecipients>,
+    #[xml_struct(ns_prefix = "t")]
     pub bcc_recipients: Option<ArrayOfRecipients>,
     pub is_read_receipt_requested: Option<bool>,
     #[xml_struct(ns_prefix = "t")]

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -475,24 +475,24 @@ pub struct Message {
     pub display_to: Option<String>,
     pub has_attachments: Option<bool>,
     pub culture: Option<String>,
-    pub sender: Option<SingleRecipient>,
-    pub to_recipients: Option<ArrayOfRecipients>,
-    pub cc_recipients: Option<ArrayOfRecipients>,
+    pub sender: Option<Recipient>,
+    pub to_recipients: Option<Vec<Recipient>>,
+    pub cc_recipients: Option<Vec<Recipient>>,
     #[xml_struct(ns_prefix = "t")]
-    pub bcc_recipients: Option<ArrayOfRecipients>,
+    pub bcc_recipients: Option<Vec<Recipient>>,
     pub is_read_receipt_requested: Option<bool>,
     #[xml_struct(ns_prefix = "t")]
     pub is_delivery_receipt_requested: Option<bool>,
     pub conversation_index: Option<String>,
     pub conversation_topic: Option<String>,
-    pub from: Option<SingleRecipient>,
+    pub from: Option<Recipient>,
     #[xml_struct(ns_prefix = "t")]
     pub internet_message_id: Option<String>,
     pub is_read: Option<bool>,
     pub is_response_requested: Option<bool>,
-    pub reply_to: Option<SingleRecipient>,
-    pub received_by: Option<SingleRecipient>,
-    pub received_representing: Option<SingleRecipient>,
+    pub reply_to: Option<Recipient>,
+    pub received_by: Option<Recipient>,
+    pub received_representing: Option<Recipient>,
     pub last_modified_name: Option<String>,
     pub last_modified_time: Option<DateTime>,
     pub is_associated: Option<bool>,
@@ -512,15 +512,9 @@ pub struct Attachments {
 /// A single mailbox.
 #[derive(Debug, Deserialize, XmlSerialize)]
 #[serde(rename_all = "PascalCase")]
-pub struct SingleRecipient {
+pub struct Recipient {
+    #[xml_struct(ns_prefix = "t")]
     pub mailbox: Mailbox,
-}
-
-/// A list of mailboxes.
-#[derive(Debug, Deserialize, XmlSerialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct ArrayOfRecipients {
-    pub mailbox: Vec<Mailbox>,
 }
 
 /// A list of Internet Message Format headers.
@@ -537,9 +531,11 @@ pub struct InternetMessageHeaders {
 #[serde(rename_all = "PascalCase")]
 pub struct Mailbox {
     /// The name of this mailbox's user.
+    #[xml_struct(ns_prefix = "t")]
     pub name: Option<String>,
 
     /// The email address for this mailbox.
+    #[xml_struct(ns_prefix = "t")]
     pub email_address: String,
 
     /// The protocol used in routing to this mailbox.

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -360,10 +360,9 @@ pub enum Folder {
 }
 
 /// An array of items.
-#[derive(Debug, Deserialize, XmlSerialize)]
+#[derive(Debug, Deserialize)]
 pub struct Items {
     #[serde(rename = "$value", default)]
-    #[xml_struct(flatten)]
     pub inner: Vec<RealItem>,
 }
 
@@ -371,8 +370,7 @@ pub struct Items {
 /// Exchange item.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/items>
-#[derive(Debug, Deserialize, XmlSerialize)]
-#[xml_struct(variant_ns_prefix = "t")]
+#[derive(Debug, Deserialize)]
 pub enum RealItem {
     Message(Message),
 }
@@ -381,7 +379,7 @@ pub enum RealItem {
 ///
 /// See [`Attachment::ItemAttachment`] for details.
 // N.B.: Commented-out variants are not yet implemented.
-#[derive(Debug, Deserialize, XmlSerialize)]
+#[derive(Debug, Deserialize)]
 pub enum AttachmentItem {
     // Item(Item),
     Message(Message),
@@ -422,162 +420,73 @@ impl XmlSerialize for DateTime {
 /// An email message.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/message-ex15websvcsotherref>
-#[derive(Default, Debug, Deserialize, XmlSerialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct Message {
     /// The MIME content of the item.
-    #[xml_struct(ns_prefix = "t")]
     pub mime_content: Option<MimeContent>,
-
     /// The item's Exchange identifier.
-    #[xml_struct(ns_prefix = "t")]
-    pub item_id: Option<ItemId>,
+    pub item_id: ItemId,
 
     /// The identifier for the containing folder.
     ///
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/parentfolderid>
-    #[xml_struct(ns_prefix = "t")]
     pub parent_folder_id: Option<FolderId>,
 
     /// The Exchange class value of the item.
     ///
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/itemclass>
-    #[xml_struct(ns_prefix = "t")]
     pub item_class: Option<String>,
 
     /// The subject of the item.
     ///
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/subject>
-    #[xml_struct(ns_prefix = "t")]
     pub subject: Option<String>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub sensitivity: Option<Sensitivity>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub body: Option<Body>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub attachments: Option<Attachments>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub date_time_received: Option<DateTime>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub size: Option<usize>,
 
     /// A list of categories describing an item.
     ///
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/categories-ex15websvcsotherref>
-    #[xml_struct(ns_prefix = "t")]
     pub categories: Option<Vec<StringElement>>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub importance: Option<Importance>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub in_reply_to: Option<String>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub is_submitted: Option<bool>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub is_draft: Option<bool>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub is_from_me: Option<bool>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub is_resend: Option<bool>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub is_unmodified: Option<bool>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub internet_message_headers: Option<InternetMessageHeaders>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub date_time_sent: Option<DateTime>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub date_time_created: Option<DateTime>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub reminder_due_by: Option<DateTime>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub reminder_is_set: Option<bool>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub reminder_minutes_before_start: Option<usize>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub display_cc: Option<String>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub display_to: Option<String>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub has_attachments: Option<bool>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub culture: Option<String>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub sender: Option<Recipient>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub to_recipients: Option<ArrayOfRecipients>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub cc_recipients: Option<ArrayOfRecipients>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub bcc_recipients: Option<ArrayOfRecipients>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub is_read_receipt_requested: Option<bool>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub is_delivery_receipt_requested: Option<bool>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub conversation_index: Option<String>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub conversation_topic: Option<String>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub from: Option<Recipient>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub internet_message_id: Option<String>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub is_read: Option<bool>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub is_response_requested: Option<bool>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub reply_to: Option<Recipient>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub received_by: Option<Recipient>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub received_representing: Option<Recipient>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub last_modified_name: Option<String>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub last_modified_time: Option<DateTime>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub is_associated: Option<bool>,
-
-    #[xml_struct(ns_prefix = "t")]
     pub conversation_id: Option<ItemId>,
 }
 

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -278,7 +278,7 @@ pub enum BaseItemId {
 /// The unique identifier of an item.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/itemid>
-#[derive(Clone, Debug, Deserialize, XmlSerialize)]
+#[derive(Debug, Deserialize, XmlSerialize)]
 pub struct ItemId {
     #[xml_struct(attribute)]
     #[serde(rename = "@Id")]
@@ -486,6 +486,7 @@ pub struct Message {
     pub conversation_index: Option<String>,
     pub conversation_topic: Option<String>,
     pub from: Option<SingleRecipient>,
+    #[xml_struct(ns_prefix = "t")]
     pub internet_message_id: Option<String>,
     pub is_read: Option<bool>,
     pub is_response_requested: Option<bool>,

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -523,12 +523,15 @@ pub struct Recipient {
     pub mailbox: Mailbox,
 }
 
-/// A util function to deserialize a list of recipients. This is necessary
-/// because quick-xml's serde data model requires the presence of an
+/// Deserializes a list of recipients.
+///
+/// `quick-xml`'s `serde` implementation requires the presence of an
 /// intermediate type when dealing with lists, and this is not compatible with
-/// our model for serialization. Note that we could directly deserialize into a
-/// Vec<Mailbox>, which would also simplify this function a bit, but this would
-/// mean using different models to represent a single vs multiple recipient(s).
+/// our model for serialization.
+/// 
+/// We could directly deserialize into a `Vec<Mailbox>`, which would also
+/// simplify this function a bit, but this would mean using different models
+/// to represent single vs. multiple recipient(s).
 fn deserialize_recipients<'de, D>(deserializer: D) -> Result<Option<Vec<Recipient>>, D::Error>
 where
     D: Deserializer<'de>,

--- a/src/types/create_item.rs
+++ b/src/types/create_item.rs
@@ -35,7 +35,7 @@ pub struct CreateItem {
     ///
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/createitem#messagedisposition-attribute>
     #[xml_struct(attribute)]
-    pub message_disposition: MessageDisposition,
+    pub message_disposition: Option<MessageDisposition>,
 
     /// The folder in which to store an item once it has been created.
     ///
@@ -80,12 +80,12 @@ impl EnvelopeBodyContents for CreateItemResponse {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct ResponseMessages {
-    pub create_item_response_message: Vec<CreateItemResponseResponseMessage>,
+    pub create_item_response_message: Vec<CreateItemResponseMessage>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
-pub struct CreateItemResponseResponseMessage {
+pub struct CreateItemResponseMessage {
     /// The status of the corresponding request, i.e. whether it succeeded or
     /// resulted in an error.
     #[serde(rename = "@ResponseClass")]

--- a/src/types/create_item.rs
+++ b/src/types/create_item.rs
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use serde::Deserialize;
+use xml_struct::XmlSerialize;
+
+use crate::{
+    types::sealed::EnvelopeBodyContents, BaseFolderId, Items, Operation, OperationResponse,
+    RealItem, ResponseClass, ResponseCode, MESSAGES_NS_URI,
+};
+
+/// Describes how an item is handled once it has been created, if it's a message
+/// item.
+///
+/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/createitem#messagedisposition-attribute>
+#[derive(Debug, XmlSerialize)]
+#[xml_struct(text)]
+pub enum MessageDisposition {
+    SaveOnly,
+    SendOnly,
+    SendAndSaveCopy,
+}
+
+/// A request to create (and optionally send) one or more Exchange item(s).
+///
+/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/createitem>
+#[derive(Debug, XmlSerialize)]
+#[xml_struct(default_ns = MESSAGES_NS_URI)]
+pub struct CreateItem {
+    /// Describes how an item is handled once it has been created, if it's a
+    /// message item.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/createitem#messagedisposition-attribute>
+    #[xml_struct(attribute)]
+    pub message_disposition: MessageDisposition,
+
+    /// The folder in which to store an item once it's been created, if it's a
+    /// message item.
+    ///
+    /// This is ignored if the message disposition is SendOnly.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/saveditemfolderid>
+    pub saved_item_folder_id: Option<BaseFolderId>,
+
+    /// The item(s) to create.
+    pub items: Items,
+}
+
+impl Operation for CreateItem {
+    type Response = CreateItemResponse;
+}
+
+impl EnvelopeBodyContents for CreateItem {
+    fn name() -> &'static str {
+        "CreateItem"
+    }
+}
+
+/// A response to a [`CreateItem`] request.
+///
+/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/createitemresponse>
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct CreateItemResponse {
+    pub response_messages: ResponseMessages,
+}
+
+impl OperationResponse for CreateItemResponse {}
+
+impl EnvelopeBodyContents for CreateItemResponse {
+    fn name() -> &'static str {
+        "CreateItemResponse"
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ResponseMessages {
+    pub create_item_response_message: Vec<CreateItemResponseResponseMessage>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct CreateItemResponseResponseMessage {
+    /// The status of the corresponding request, i.e. whether it succeeded or
+    /// resulted in an error.
+    #[serde(rename = "@ResponseClass")]
+    pub response_class: ResponseClass,
+
+    pub response_code: Option<ResponseCode>,
+
+    pub message_text: Option<String>,
+
+    pub items: Items,
+}

--- a/src/types/create_item.rs
+++ b/src/types/create_item.rs
@@ -6,7 +6,8 @@ use serde::Deserialize;
 use xml_struct::XmlSerialize;
 
 use crate::{
-    types::sealed::EnvelopeBodyContents, BaseFolderId, Items, Operation, OperationResponse, ResponseClass, ResponseCode, MESSAGES_NS_URI,
+    types::sealed::EnvelopeBodyContents, BaseFolderId, Items, Operation, OperationResponse,
+    ResponseClass, ResponseCode, MESSAGES_NS_URI,
 };
 
 /// Describes how an item is handled once it has been created, if it's a message

--- a/src/types/create_item.rs
+++ b/src/types/create_item.rs
@@ -6,8 +6,7 @@ use serde::Deserialize;
 use xml_struct::XmlSerialize;
 
 use crate::{
-    types::sealed::EnvelopeBodyContents, BaseFolderId, Items, Operation, OperationResponse,
-    RealItem, ResponseClass, ResponseCode, MESSAGES_NS_URI,
+    types::sealed::EnvelopeBodyContents, BaseFolderId, Items, Operation, OperationResponse, ResponseClass, ResponseCode, MESSAGES_NS_URI,
 };
 
 /// Describes how an item is handled once it has been created, if it's a message

--- a/src/types/create_item.rs
+++ b/src/types/create_item.rs
@@ -10,8 +10,7 @@ use crate::{
     ResponseClass, ResponseCode, MESSAGES_NS_URI,
 };
 
-/// Describes how an item is handled once it has been created, if it's a message
-/// item.
+/// The action an Exchange server will take upon creating a `Message` item.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/createitem#messagedisposition-attribute>
 #[derive(Debug, XmlSerialize)]
@@ -28,22 +27,26 @@ pub enum MessageDisposition {
 #[derive(Debug, XmlSerialize)]
 #[xml_struct(default_ns = MESSAGES_NS_URI)]
 pub struct CreateItem {
-    /// Describes how an item is handled once it has been created, if it's a
-    /// message item.
+    /// The action the Exchange server will take upon creating this item.
+    ///
+    /// This field is required for and only applicable to [`Message`] items.
+    ///
+    /// [`Message`]: `crate::Message`
     ///
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/createitem#messagedisposition-attribute>
     #[xml_struct(attribute)]
     pub message_disposition: MessageDisposition,
 
-    /// The folder in which to store an item once it's been created, if it's a
-    /// message item.
+    /// The folder in which to store an item once it has been created.
     ///
-    /// This is ignored if the message disposition is SendOnly.
+    /// This is ignored if `message_disposition` is [`SendOnly`].
     ///
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/saveditemfolderid>
+    ///
+    /// [`SendOnly`]: [`MessageDisposition::SendOnly`]
     pub saved_item_folder_id: Option<BaseFolderId>,
 
-    /// The item(s) to create.
+    /// The item or items to create.
     pub items: Items,
 }
 

--- a/src/types/create_item.rs
+++ b/src/types/create_item.rs
@@ -53,9 +53,19 @@ pub struct CreateItem {
 /// A new item that appears in a CreateItem request.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/items>
+// N.B.: Commented-out variants are not yet implemented.
+#[non_exhaustive]
 #[derive(Debug, XmlSerialize)]
 pub enum Item {
+    // Item(Item),
     Message(Message),
+    // CalendarItem(CalendarItem),
+    // Contact(Contact),
+    // Task(Task),
+    // MeetingMessage(MeetingMessage),
+    // MeetingRequest(MeetingRequest),
+    // MeetingResponse(MeetingResponse),
+    // MeetingCancellation(MeetingCancellation),
 }
 
 /// An email message to create.

--- a/src/types/create_item.rs
+++ b/src/types/create_item.rs
@@ -6,8 +6,8 @@ use serde::Deserialize;
 use xml_struct::XmlSerialize;
 
 use crate::{
-    types::sealed::EnvelopeBodyContents, BaseFolderId, Items, Operation, OperationResponse,
-    ResponseClass, ResponseCode, MESSAGES_NS_URI,
+    types::sealed::EnvelopeBodyContents, ArrayOfRecipients, BaseFolderId, Items, MimeContent,
+    Operation, OperationResponse, ResponseClass, ResponseCode, MESSAGES_NS_URI,
 };
 
 /// The action an Exchange server will take upon creating a `Message` item.
@@ -47,7 +47,38 @@ pub struct CreateItem {
     pub saved_item_folder_id: Option<BaseFolderId>,
 
     /// The item or items to create.
-    pub items: Items,
+    pub items: Vec<Item>,
+}
+
+/// A new item that appears in a CreateItem request.
+///
+/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/items>
+#[derive(Debug, XmlSerialize)]
+pub enum Item {
+    Message(Message),
+}
+
+/// An email message to create.
+///
+/// This struct follows the same specification to [`common::Message`], but has a
+/// few differences that allow the creation of new messages without forcing any
+/// tradeoff on strictness when deserializing; for example not making the item
+/// ID a required field.
+///
+/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/message-ex15websvcsotherref>
+///
+/// [`common::message`]: crate::Message
+#[derive(Debug, Default, XmlSerialize)]
+pub struct Message {
+    /// The MIME content of the item.
+    pub mime_content: Option<MimeContent>,
+    // Whether to request a delivery receipt.
+    pub is_delivery_receipt_requested: Option<bool>,
+    // The message ID for the message, semantically identical to the Message-ID
+    // header.
+    pub internet_message_id: Option<String>,
+    // Recipients to include as Bcc, who won't be included in the MIME content.
+    pub bcc_recipients: Option<ArrayOfRecipients>,
 }
 
 impl Operation for CreateItem {

--- a/src/types/get_item.rs
+++ b/src/types/get_item.rs
@@ -6,8 +6,8 @@ use serde::Deserialize;
 use xml_struct::XmlSerialize;
 
 use crate::{
-    types::sealed::EnvelopeBodyContents, BaseItemId, ItemShape, Operation, OperationResponse,
-    RealItem, ResponseClass, ResponseCode, MESSAGES_NS_URI,
+    types::sealed::EnvelopeBodyContents, BaseItemId, ItemShape, Items, Operation,
+    OperationResponse, ResponseClass, ResponseCode, MESSAGES_NS_URI,
 };
 
 /// A request for the properties of one or more Exchange items, e.g. messages,
@@ -75,10 +75,4 @@ pub struct GetItemResponseMessage {
     pub message_text: Option<String>,
 
     pub items: Items,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct Items {
-    #[serde(rename = "$value")]
-    pub inner: Vec<RealItem>,
 }


### PR DESCRIPTION
This change undoes part of https://github.com/thunderbird/ews-rs/pull/10 following complications from making the item ID optional. See https://phabricator.services.mozilla.com/D211258 for more context.

Instead of using `common::Message` for both serialization and deserialization, this change introduces a new `Message` type that is specific to the `CreateItem` operation. For now we agreed on only adding the fields that Thunderbird uses, but ultimately `create_item::Message` should include every field that `common::Message` does.