### PR TITLE
Derive the `Default` trait for `Mailbox`

### DIFF
--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -570,7 +570,7 @@ pub struct InternetMessageHeaders {
 /// A reference to a user or address which can send or receive mail.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/mailbox>
-#[derive(Clone, Debug, Deserialize, XmlSerialize, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, XmlSerialize, PartialEq)]
 #[serde(rename_all = "PascalCase")]
 pub struct Mailbox {
     /// The name of this mailbox's user.


### PR DESCRIPTION
Required to use the struct update syntax (with `..Default:default()`) on `Mailbox` in https://phabricator.services.mozilla.com/D212838

At some point we might want to go and audit the types in this crate to eagerly derive more std traits for them.