### PR TITLE
Turn `MessageDisposition` back into an `Option`

### DIFF
--- a/src/types/create_item.rs
+++ b/src/types/create_item.rs
@@ -35,7 +35,7 @@ pub struct CreateItem {
     ///
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/createitem#messagedisposition-attribute>
     #[xml_struct(attribute)]
-    pub message_disposition: MessageDisposition,
+    pub message_disposition: Option<MessageDisposition>,
 
     /// The folder in which to store an item once it has been created.
     ///


### PR DESCRIPTION
This is something that I changed in #15 because I assumed it would always be mandatory. After reading the documentation again, I realised it's only the case for message items.