### PR TITLE
Expose `name()` on `Operation` to allow for debugging

### DIFF
--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -989,7 +989,7 @@ mod tests {
 
         // Ensure the first recipient correctly has a name and address.
         assert_eq!(
-            recipients.get(0).expect("no recipient at index 0"),
+            recipients.first().expect("no recipient at index 0"),
             &Recipient {
                 mailbox: Mailbox {
                     name: Some("Alice Test".into()),

--- a/src/types/operations.rs
+++ b/src/types/operations.rs
@@ -20,6 +20,10 @@ pub trait Operation: XmlSerialize + sealed::EnvelopeBodyContents {
     /// operation.
     type Response: OperationResponse;
 
+    /// Gets the name of the operation.
+    ///
+    /// This is the same as the local part of the name of the XML element used
+    /// to represent this option.
     fn name() -> &'static str {
         <Self as sealed::EnvelopeBodyContents>::name()
     }

--- a/src/types/operations.rs
+++ b/src/types/operations.rs
@@ -19,6 +19,10 @@ pub trait Operation: XmlSerialize + sealed::EnvelopeBodyContents {
     /// The structure returned by EWS in response to requests containing this
     /// operation.
     type Response: OperationResponse;
+
+    fn name() -> &'static str {
+        <Self as sealed::EnvelopeBodyContents>::name()
+    }
 }
 
 /// A marker trait for EWS operation responses.

--- a/src/types/soap.rs
+++ b/src/types/soap.rs
@@ -8,7 +8,8 @@ use quick_xml::{
 };
 
 use crate::{
-    Error, MessageXml, Operation, OperationResponse, ResponseCode, SOAP_NS_URI, TYPES_NS_URI,
+    types::sealed, Error, MessageXml, Operation, OperationResponse, ResponseCode, SOAP_NS_URI,
+    TYPES_NS_URI,
 };
 
 mod de;
@@ -48,7 +49,8 @@ where
         writer.write_event(Event::Start(BytesStart::new(SOAP_BODY)))?;
 
         // Write the operation itself.
-        self.body.serialize_as_element(&mut writer, B::name())?;
+        self.body
+            .serialize_as_element(&mut writer, <B as sealed::EnvelopeBodyContents>::name())?;
 
         writer.write_event(Event::End(BytesEnd::new(SOAP_BODY)))?;
         writer.write_event(Event::End(BytesEnd::new(SOAP_ENVELOPE)))?;


### PR DESCRIPTION
We have the `name()` function as part of `sealed::EnvelopeBodyContents` already, but we don't want to unseal that to expose the function. We can, however, make it available as part of the `Operation` impl.