### PR TITLE
Update documentation and get rid of serialize-only Message type

### DIFF
--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -327,7 +327,7 @@ pub enum BaseItemId {
 /// The unique identifier of an item.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/itemid>
-#[derive(Clone, Default, Debug, Deserialize, XmlSerialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, XmlSerialize, PartialEq)]
 pub struct ItemId {
     #[xml_struct(attribute)]
     #[serde(rename = "@Id")]
@@ -419,7 +419,7 @@ pub struct Items {
 /// Exchange item.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/items>
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, XmlSerialize)]
 pub enum RealItem {
     Message(Message),
 }
@@ -475,8 +475,9 @@ impl XmlSerialize for DateTime {
 pub struct Message {
     /// The MIME content of the item.
     pub mime_content: Option<MimeContent>,
+
     /// The item's Exchange identifier.
-    pub item_id: ItemId,
+    pub item_id: Option<ItemId>,
 
     /// The identifier for the containing folder.
     ///
@@ -617,7 +618,7 @@ pub struct InternetMessageHeaders {
 /// A reference to a user or address which can send or receive mail.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/mailbox>
-#[derive(Clone, Debug, Default, Deserialize, XmlSerialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, XmlSerialize, PartialEq)]
 #[serde(rename_all = "PascalCase")]
 pub struct Mailbox {
     /// The name of this mailbox's user.

--- a/src/types/create_item.rs
+++ b/src/types/create_item.rs
@@ -6,12 +6,11 @@ use serde::Deserialize;
 use xml_struct::XmlSerialize;
 
 use crate::{
-    types::sealed::EnvelopeBodyContents, ArrayOfRecipients, BaseFolderId, ExtendedFieldURI, Items,
-    MessageDisposition, MimeContent, Operation, OperationResponse, ResponseClass, ResponseCode,
-    MESSAGES_NS_URI,
+    types::sealed::EnvelopeBodyContents, BaseFolderId, ExtendedFieldURI, Items, MessageDisposition,
+    Operation, OperationResponse, RealItem, ResponseClass, ResponseCode, MESSAGES_NS_URI,
 };
 
-/// A request to create (and optionally send) one or more Exchange item(s).
+/// A request to create (and optionally send) one or more Exchange items.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/createitem>
 #[derive(Clone, Debug, XmlSerialize)]
@@ -33,64 +32,11 @@ pub struct CreateItem {
     ///
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/saveditemfolderid>
     ///
-    /// [`SendOnly`]: [`MessageDisposition::SendOnly`]
+    /// [`SendOnly`]: `MessageDisposition::SendOnly`
     pub saved_item_folder_id: Option<BaseFolderId>,
 
     /// The item or items to create.
-    pub items: Vec<Item>,
-}
-
-/// A new item that appears in a CreateItem request.
-///
-/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/items>
-// N.B.: Commented-out variants are not yet implemented.
-#[non_exhaustive]
-#[derive(Clone, Debug, XmlSerialize)]
-#[xml_struct(variant_ns_prefix = "t")]
-pub enum Item {
-    // Item(Item),
-    Message(Message),
-    // CalendarItem(CalendarItem),
-    // Contact(Contact),
-    // Task(Task),
-    // MeetingMessage(MeetingMessage),
-    // MeetingRequest(MeetingRequest),
-    // MeetingResponse(MeetingResponse),
-    // MeetingCancellation(MeetingCancellation),
-}
-
-/// An email message to create.
-///
-/// This struct follows the same specification to [`common::Message`], but has a
-/// few differences that allow the creation of new messages without forcing any
-/// tradeoff on strictness when deserializing; for example not making the item
-/// ID a required field.
-///
-/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/message-ex15websvcsotherref>
-///
-/// [`common::message`]: crate::Message
-#[derive(Clone, Debug, Default, XmlSerialize)]
-pub struct Message {
-    /// The MIME content of the item.
-    #[xml_struct(ns_prefix = "t")]
-    pub mime_content: Option<MimeContent>,
-
-    // Whether to request a delivery receipt.
-    #[xml_struct(ns_prefix = "t")]
-    pub is_delivery_receipt_requested: Option<bool>,
-
-    // The message ID for the message, semantically identical to the Message-ID
-    // header.
-    #[xml_struct(ns_prefix = "t")]
-    pub internet_message_id: Option<String>,
-
-    // Recipients to include as Bcc, who won't be included in the MIME content.
-    #[xml_struct(ns_prefix = "t")]
-    pub bcc_recipients: Option<ArrayOfRecipients>,
-
-    // Extended MAPI properties to set on the message.
-    #[xml_struct(ns_prefix = "t")]
-    pub extended_property: Option<Vec<ExtendedProperty>>,
+    pub items: Vec<RealItem>,
 }
 
 /// An extended MAPI property to set on the message.


### PR DESCRIPTION
This proposes a series of updates to Toby's PR at https://github.com/thunderbird/ews-rs/pull/18 to more rapidly illustrate what I'm expecting.