### PR TITLE
Support XML serialization for UpdateItem

### DIFF
--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -533,6 +533,7 @@ pub struct Message {
     pub conversation_topic: Option<String>,
     pub from: Option<Recipient>,
     pub internet_message_id: Option<String>,
+    #[xml_struct(ns_prefix = "t")]
     pub is_read: Option<bool>,
     pub is_response_requested: Option<bool>,
     pub reply_to: Option<Recipient>,

--- a/src/types/update_item.rs
+++ b/src/types/update_item.rs
@@ -107,19 +107,10 @@ pub enum ConflictResolution {
     AlwaysOverwrite,
 }
 
-/// A list of updates to items, with each element representing a single item.
-///
-/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/itemchanges>
 #[derive(Clone, Debug, XmlSerialize)]
-pub struct ItemChanges {
+pub struct ItemChange {
     #[xml_struct(ns_prefix = "t")]
-    pub item_changes: Vec<ItemChange>,
-}
-
-#[derive(Clone, Debug, XmlSerialize)]
-#[xml_struct(variant_ns_prefix = "t")]
-pub enum ItemChange {
-    ItemChange(ItemChangeInner),
+    pub item_change: ItemChangeInner,
 }
 
 /// One or more updates to a single item.

--- a/src/types/update_item.rs
+++ b/src/types/update_item.rs
@@ -2,18 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::types::common::{BaseItemId, Message, MessageDisposition, PathToElement};
-use crate::{
-    types::sealed::EnvelopeBodyContents, Items, Operation, OperationResponse, ResponseClass,
-    ResponseCode,
-};
-use serde::Deserialize;
-use xml_struct::XmlSerialize;
+ use crate::types::common::{BaseItemId, Message, MessageDisposition, PathToElement};
+ use crate::{
+     types::sealed::EnvelopeBodyContents, Items, Operation, OperationResponse, ResponseClass,
+     ResponseCode, MESSAGES_NS_URI,
+ };
+ use serde::Deserialize;
+ use xml_struct::XmlSerialize;
 
 /// A request to update properties of one or more Exchange items.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/updateitem>
 #[derive(Clone, Debug, XmlSerialize)]
+#[xml_struct(default_ns = MESSAGES_NS_URI)]
 pub struct UpdateItem {
     /// The action the Exchange server will take upon updating this item.
     ///
@@ -21,7 +22,7 @@ pub struct UpdateItem {
     ///
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/updateitem#messagedisposition-attribute>
     #[xml_struct(attribute)]
-    pub message_disposition: Option<MessageDisposition>,
+    pub message_disposition: MessageDisposition,
 
     /// The method the Exchange server will use to resolve conflicts between
     /// updates.
@@ -37,7 +38,7 @@ pub struct UpdateItem {
     /// A list of items and their corresponding updates.
     ///
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/itemchanges>
-    pub item_changes: ItemChanges,
+    pub item_changes: Vec<ItemChange>,
 }
 
 impl Operation for UpdateItem {
@@ -78,6 +79,7 @@ pub struct ResponseMessages {
 pub struct UpdateItemResponseMessage {
     /// The status of the corresponding request, i.e. whether it succeeded or
     /// resulted in an error.
+    #[serde(rename = "@ResponseClass")]
     pub response_class: ResponseClass,
 
     pub response_code: Option<ResponseCode>,
@@ -110,19 +112,28 @@ pub enum ConflictResolution {
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/itemchanges>
 #[derive(Clone, Debug, XmlSerialize)]
 pub struct ItemChanges {
+    #[xml_struct(ns_prefix = "t")]
     pub item_changes: Vec<ItemChange>,
+}
+
+#[derive(Clone, Debug, XmlSerialize)]
+#[xml_struct(variant_ns_prefix = "t")]
+pub enum ItemChange{
+    ItemChange(ItemChangeInner),
 }
 
 /// One or more updates to a single item.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/itemchange>
 #[derive(Clone, Debug, XmlSerialize)]
-pub struct ItemChange {
+pub struct ItemChangeInner {
     /// The ID of the item to be updated.
+    #[xml_struct(flatten, ns_prefix = "t")]
     pub item_id: BaseItemId,
 
     /// The changes to make to the item, including appending, setting, or
     /// deleting fields.
+    #[xml_struct(ns_prefix = "t")]
     pub updates: Updates,
 }
 
@@ -131,21 +142,24 @@ pub struct ItemChange {
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/updates-item>
 #[derive(Clone, Debug, XmlSerialize)]
 pub struct Updates {
-    #[xml_struct(flatten)]
+    #[xml_struct(flatten, ns_prefix = "t")]
     pub inner: Vec<ItemChangeDescription>,
 }
 
 /// An individual change to a single field.
 #[derive(Clone, Debug, XmlSerialize)]
+#[xml_struct(variant_ns_prefix = "t")]
 pub enum ItemChangeDescription {
     /// An update setting the value of a single field.
     ///
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/setitemfield>
     SetItemField {
         /// The field to be updated.
+        #[xml_struct(flatten, ns_prefix = "t")]
         field_uri: PathToElement,
 
         /// The new value of the specified field.
+        #[xml_struct(ns_prefix = "t")]
         message: Message,
     },
 }

--- a/src/types/update_item.rs
+++ b/src/types/update_item.rs
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
- use crate::types::common::{BaseItemId, Message, MessageDisposition, PathToElement};
- use crate::{
-     types::sealed::EnvelopeBodyContents, Items, Operation, OperationResponse, ResponseClass,
-     ResponseCode, MESSAGES_NS_URI,
- };
- use serde::Deserialize;
- use xml_struct::XmlSerialize;
+use crate::types::common::{BaseItemId, Message, MessageDisposition, PathToElement};
+use crate::{
+    types::sealed::EnvelopeBodyContents, Items, Operation, OperationResponse, ResponseClass,
+    ResponseCode, MESSAGES_NS_URI,
+};
+use serde::Deserialize;
+use xml_struct::XmlSerialize;
 
 /// A request to update properties of one or more Exchange items.
 ///
@@ -118,7 +118,7 @@ pub struct ItemChanges {
 
 #[derive(Clone, Debug, XmlSerialize)]
 #[xml_struct(variant_ns_prefix = "t")]
-pub enum ItemChange{
+pub enum ItemChange {
     ItemChange(ItemChangeInner),
 }
 


### PR DESCRIPTION
I made some changes to support the serialization. If you don't like the enum approach, could you play around and see if there's a better way? I'll put up the changes in c-c so you can bring both down to play.