### PR TITLE
Make `Operation::name()` a method rather than an associated function

### DIFF
--- a/src/types/operations.rs
+++ b/src/types/operations.rs
@@ -24,7 +24,7 @@ pub trait Operation: XmlSerialize + sealed::EnvelopeBodyContents + std::fmt::Deb
     ///
     /// This is the same as the local part of the name of the XML element used
     /// to represent this option.
-    fn name() -> &'static str {
+    fn name(&self) -> &'static str {
         <Self as sealed::EnvelopeBodyContents>::name()
     }
 }


### PR DESCRIPTION
Looks like an oversight from #22. Retrieving the name from an operation should be done as `op.name()`; using an associated function would mean we'd need to call e.g. `GetItem::name()`, which would make the method a bit redundant.