### PR TITLE
Changes to SOAP structure to support optional Header

### DIFF
--- a/src/types/soap.rs
+++ b/src/types/soap.rs
@@ -80,6 +80,14 @@ impl SoapHeader for RequestServerVersion {
     }
 }
 
+// Implement `SoapHeader` for `()` to represent an empty or no-op header
+impl SoapHeader for () {
+    fn serialize_header(&self, _writer: &mut Writer<Vec<u8>>) -> Result<(), Error> {
+        // No-op for empty header
+        Ok(())
+    }
+}
+
 /// A SOAP envelope containing the body of an EWS operation or response.
 ///
 /// See <https://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383494>


### PR DESCRIPTION
Hey gents, I started looking into Mark as Junk, and realized that we'll likely need to support <Soap:Header> for some operations that are only available on specific versions of EWS. Here's an example:

https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/markasjunk-operation#markasjunk-operation-request-example-add-a-sender-to-the-blocked-sender-list