### PR TITLE
Added support to update junk status

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -16,3 +16,4 @@ pub mod get_item;
 pub mod sync_folder_hierarchy;
 pub mod sync_folder_items;
 pub mod update_item;
+pub mod update_junk_status;

--- a/src/types/soap.rs
+++ b/src/types/soap.rs
@@ -80,6 +80,14 @@ impl SoapHeader for RequestServerVersion {
     }
 }
 
+// Implement `SoapHeader` for `()` to represent an empty or no-op header
+impl SoapHeader for () {
+    fn serialize_header(&self, _writer: &mut Writer<Vec<u8>>) -> Result<(), Error> {
+        // No-op for empty header
+        Ok(())
+    }
+}
+
 /// A SOAP envelope containing the body of an EWS operation or response.
 ///
 /// See <https://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383494>

--- a/src/types/update_junk_status.rs
+++ b/src/types/update_junk_status.rs
@@ -1,5 +1,7 @@
 use crate::types::sealed::EnvelopeBodyContents;
-use crate::{BaseItemId, Operation, OperationResponse, MESSAGES_NS_URI};
+use crate::{
+    BaseItemId, Operation, OperationResponse, ResponseClass, ResponseCode, MESSAGES_NS_URI,
+};
 use serde::Deserialize;
 use xml_struct::XmlSerialize;
 
@@ -40,8 +42,10 @@ pub struct ItemIds {
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
+#[serde(rename = "m:MarkAsJunkResponse")]
 pub struct MarkAsJunkResponse {
-    // Add fields as needed to match the structure of the response from EWS.
+    #[serde(rename = "m:ResponseMessages")]
+    pub response_messages: ResponseMessages,
 }
 
 impl OperationResponse for MarkAsJunkResponse {}
@@ -50,4 +54,35 @@ impl EnvelopeBodyContents for MarkAsJunkResponse {
     fn name() -> &'static str {
         "MarkAsJunkResponse"
     }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ResponseMessages {
+    #[serde(rename = "m:MarkAsJunkResponseMessage")]
+    pub mark_as_junk_response_message: Vec<MarkAsJunkResponseMessage>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct MarkAsJunkResponseMessage {
+    /// The status of the corresponding request, i.e. whether it succeeded or
+    /// resulted in an error.
+    #[serde(rename = "@ResponseClass")]
+    pub response_class: ResponseClass,
+
+    pub response_code: Option<ResponseCode>,
+
+    pub moved_item_id: Option<MovedItemId>, // Optional in case it’s not present
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[serde(rename = "t:MovedItemId")]
+pub struct MovedItemId {
+    #[serde(rename = "@Id")]
+    pub id: String,
+
+    #[serde(rename = "@ChangeKey")]
+    pub change_key: String,
 }

--- a/src/types/update_junk_status.rs
+++ b/src/types/update_junk_status.rs
@@ -1,0 +1,53 @@
+use crate::types::sealed::EnvelopeBodyContents;
+use crate::{BaseItemId, Operation, OperationResponse, MESSAGES_NS_URI};
+use serde::Deserialize;
+use xml_struct::XmlSerialize;
+
+/// A request to update junk status of one or more Exchange items.
+///
+/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/markasjunk>
+#[derive(Clone, Debug, XmlSerialize)]
+#[xml_struct(default_ns = MESSAGES_NS_URI)]
+pub struct MarkAsJunk {
+    /// Specifies if the item is considered junk.
+    #[xml_struct(attribute)]
+    pub is_junk: bool,
+
+    /// Specifies if the item should be moved.
+    #[xml_struct(attribute)]
+    pub move_item: bool,
+
+    /// A list of item IDs to mark as junk.
+    #[xml_struct(ns_prefix = "m")]
+    pub item_ids: ItemIds,
+}
+
+impl Operation for MarkAsJunk {
+    type Response = MarkAsJunkResponse;
+}
+
+impl EnvelopeBodyContents for MarkAsJunk {
+    fn name() -> &'static str {
+        "m:MarkAsJunk"
+    }
+}
+
+#[derive(Clone, Debug, XmlSerialize)]
+pub struct ItemIds {
+    #[xml_struct(flatten, ns_prefix = "t")]
+    pub items: Vec<BaseItemId>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct MarkAsJunkResponse {
+    // Add fields as needed to match the structure of the response from EWS.
+}
+
+impl OperationResponse for MarkAsJunkResponse {}
+
+impl EnvelopeBodyContents for MarkAsJunkResponse {
+    fn name() -> &'static str {
+        "MarkAsJunkResponse"
+    }
+}


### PR DESCRIPTION
Oops, I rebased this branch on top of the other SOAP Headers branch and now it all seems to be in here - I may need your help to fix that.

This is designed to facilitate this:
https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/markasjunk-operation