### PR TITLE
Add response code field to GetFolder response

### DIFF
--- a/src/types/get_folder.rs
+++ b/src/types/get_folder.rs
@@ -7,7 +7,7 @@ use xml_struct::XmlSerialize;
 
 use crate::{
     types::sealed::EnvelopeBodyContents, BaseFolderId, Folder, FolderShape, Operation,
-    OperationResponse, ResponseClass, MESSAGES_NS_URI,
+    OperationResponse, ResponseClass, ResponseCode, MESSAGES_NS_URI,
 };
 
 /// A request to get information on one or more folders.
@@ -70,6 +70,10 @@ pub struct GetFolderResponseMessage {
     /// resulted in an error.
     #[serde(rename = "@ResponseClass")]
     pub response_class: ResponseClass,
+
+    pub response_code: Option<ResponseCode>,
+
+    pub message_text: Option<String>,
 
     /// A collection of the retrieved folders.
     pub folders: Folders,


### PR DESCRIPTION
Consumers can't presently distinguish between error types. For the Thunderbird case, we request folders by distinguished ID knowing that not all of them may be present on the server. We should be checking that the error we receive in these cases is `ErrorFolderNotFound`.