### PR TITLE
Derive additional useful traits for ResponseCode

### DIFF
--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -253,9 +253,11 @@ pub enum ResponseClass {
 /// any.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/responsecode>
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq)]
 pub enum ResponseCode {
+    #[default]
     NoError,
+
     ErrorAccessDenied,
     ErrorAccessModeSpecified,
     ErrorAccountDisabled,


### PR DESCRIPTION
`ResponseCode` is no longer `String`-based, so we can use `Copy`. It might also make sense to provide a default value of `NoError` for cases where it might be the contents of an `Option`.