### PR TITLE
Correct Folder namespaces and CreateFolderResponse structure

### DIFF
--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -804,18 +804,32 @@ pub struct ItemId {
 
 /// The representation of a folder in an EWS operation.
 #[derive(Clone, Debug, Deserialize, XmlSerialize)]
+#[xml_struct(variant_ns_prefix = "t")]
 pub enum Folder {
     /// A calendar folder in a mailbox.
     ///
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/calendarfolder>
     #[serde(rename_all = "PascalCase")]
     CalendarFolder {
+        #[xml_struct(ns_prefix = "t")]
         folder_id: Option<FolderId>,
+
+        #[xml_struct(ns_prefix = "t")]
         parent_folder_id: Option<FolderId>,
+
+        #[xml_struct(ns_prefix = "t")]
         folder_class: Option<String>,
+
+        #[xml_struct(ns_prefix = "t")]
         display_name: Option<String>,
+
+        #[xml_struct(ns_prefix = "t")]
         total_count: Option<u32>,
+
+        #[xml_struct(ns_prefix = "t")]
         child_folder_count: Option<u32>,
+
+        #[xml_struct(ns_prefix = "t")]
         extended_property: Option<Vec<ExtendedProperty>>,
     },
 
@@ -824,12 +838,25 @@ pub enum Folder {
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/contactsfolder>
     #[serde(rename_all = "PascalCase")]
     ContactsFolder {
+        #[xml_struct(ns_prefix = "t")]
         folder_id: Option<FolderId>,
+
+        #[xml_struct(ns_prefix = "t")]
         parent_folder_id: Option<FolderId>,
+
+        #[xml_struct(ns_prefix = "t")]
         folder_class: Option<String>,
+
+        #[xml_struct(ns_prefix = "t")]
         display_name: Option<String>,
+
+        #[xml_struct(ns_prefix = "t")]
         total_count: Option<u32>,
+
+        #[xml_struct(ns_prefix = "t")]
         child_folder_count: Option<u32>,
+
+        #[xml_struct(ns_prefix = "t")]
         extended_property: Option<Vec<ExtendedProperty>>,
     },
 
@@ -838,13 +865,28 @@ pub enum Folder {
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/folder>
     #[serde(rename_all = "PascalCase")]
     Folder {
+        #[xml_struct(ns_prefix = "t")]
         folder_id: Option<FolderId>,
+
+        #[xml_struct(ns_prefix = "t")]
         parent_folder_id: Option<FolderId>,
+
+        #[xml_struct(ns_prefix = "t")]
         folder_class: Option<String>,
+
+        #[xml_struct(ns_prefix = "t")]
         display_name: Option<String>,
+
+        #[xml_struct(ns_prefix = "t")]
         total_count: Option<u32>,
+
+        #[xml_struct(ns_prefix = "t")]
         child_folder_count: Option<u32>,
+
+        #[xml_struct(ns_prefix = "t")]
         extended_property: Option<Vec<ExtendedProperty>>,
+
+        #[xml_struct(ns_prefix = "t")]
         unread_count: Option<u32>,
     },
 
@@ -853,12 +895,25 @@ pub enum Folder {
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/searchfolder>
     #[serde(rename_all = "PascalCase")]
     SearchFolder {
+        #[xml_struct(ns_prefix = "t")]
         folder_id: Option<FolderId>,
+
+        #[xml_struct(ns_prefix = "t")]
         parent_folder_id: Option<FolderId>,
+
+        #[xml_struct(ns_prefix = "t")]
         folder_class: Option<String>,
+
+        #[xml_struct(ns_prefix = "t")]
         display_name: Option<String>,
+
+        #[xml_struct(ns_prefix = "t")]
         total_count: Option<u32>,
+
+        #[xml_struct(ns_prefix = "t")]
         child_folder_count: Option<u32>,
+
+        #[xml_struct(ns_prefix = "t")]
         extended_property: Option<Vec<ExtendedProperty>>,
     },
 
@@ -867,12 +922,25 @@ pub enum Folder {
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/tasksfolder>
     #[serde(rename_all = "PascalCase")]
     TasksFolder {
+        #[xml_struct(ns_prefix = "t")]
         folder_id: Option<FolderId>,
+
+        #[xml_struct(ns_prefix = "t")]
         parent_folder_id: Option<FolderId>,
+
+        #[xml_struct(ns_prefix = "t")]
         folder_class: Option<String>,
+
+        #[xml_struct(ns_prefix = "t")]
         display_name: Option<String>,
+
+        #[xml_struct(ns_prefix = "t")]
         total_count: Option<u32>,
+
+        #[xml_struct(ns_prefix = "t")]
         child_folder_count: Option<u32>,
+
+        #[xml_struct(ns_prefix = "t")]
         extended_property: Option<Vec<ExtendedProperty>>,
     },
 }
@@ -882,6 +950,15 @@ pub enum Folder {
 pub struct Items {
     #[serde(rename = "$value", default)]
     pub inner: Vec<RealItem>,
+}
+
+/// A collection of information on Exchange folders.
+///
+/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/folders-ex15websvcsotherref>
+#[derive(Clone, Debug, Deserialize)]
+pub struct Folders {
+    #[serde(rename = "$value", default)]
+    pub inner: Vec<Folder>,
 }
 
 /// An item which may appear as the result of a request to read or modify an

--- a/src/types/create_folder.rs
+++ b/src/types/create_folder.rs
@@ -6,8 +6,8 @@ use serde::Deserialize;
 use xml_struct::XmlSerialize;
 
 use crate::{
-    types::sealed::EnvelopeBodyContents, BaseFolderId, Folder, Operation, OperationResponse,
-    ResponseClass, ResponseCode, MESSAGES_NS_URI,
+    types::sealed::EnvelopeBodyContents, BaseFolderId, Folder, Folders, Operation,
+    OperationResponse, ResponseClass, ResponseCode, MESSAGES_NS_URI,
 };
 
 /// A request to create a new folder.
@@ -65,5 +65,5 @@ pub struct CreateFolderResponseMessage {
 
     pub message_text: Option<String>,
 
-    pub folders: Vec<Folder>,
+    pub folders: Folders,
 }

--- a/src/types/get_folder.rs
+++ b/src/types/get_folder.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use xml_struct::XmlSerialize;
 
 use crate::{
-    types::sealed::EnvelopeBodyContents, BaseFolderId, Folder, FolderShape, Operation,
+    types::sealed::EnvelopeBodyContents, BaseFolderId, FolderShape, Folders, Operation,
     OperationResponse, ResponseClass, ResponseCode, MESSAGES_NS_URI,
 };
 
@@ -77,13 +77,4 @@ pub struct GetFolderResponseMessage {
 
     /// A collection of the retrieved folders.
     pub folders: Folders,
-}
-
-/// A collection of information on Exchange folders.
-///
-/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/folders-ex15websvcsotherref>
-#[derive(Clone, Debug, Deserialize)]
-pub struct Folders {
-    #[serde(rename = "$value")]
-    pub inner: Vec<Folder>,
 }

--- a/src/types/soap.rs
+++ b/src/types/soap.rs
@@ -345,7 +345,7 @@ impl<'content> ScopedReader<'content> {
         // send all responses as UTF-8. We'll encounter bigger problems
         // elsewhere if we run into a non-UTF-8 document, most notably that we
         // currently don't enable the `encoding` feature for quick-xml.
-        return Ok(Self::from_bytes(content));
+        Ok(Self::from_bytes(content))
     }
 
     /// Gets a string representation of the contents of the current reader.


### PR DESCRIPTION
Serialization of `CreateFolder` and deserialization of `CreateFolderResponse` were incorrect due to unspecified namespace prefixes on the `Folder` enum and use of the incorrect type in the response struct.