### PR TITLE
Correct structure of SyncFolderHierarchy Changes for delete

### DIFF
--- a/src/types/sync_folder_hierarchy.rs
+++ b/src/types/sync_folder_hierarchy.rs
@@ -129,8 +129,9 @@ pub enum Change {
     /// A deletion of a folder.
     ///
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/delete-foldersync>
-    Delete(
+    #[serde(rename_all = "PascalCase")]
+    Delete {
         /// The EWS ID for the deleted folder.
-        FolderId,
-    ),
+        folder_id: FolderId,
+    },
 }


### PR DESCRIPTION
The `Delete` variant incorrectly omitted the field name for the contained folder ID.