### PR TITLE
Add support for the References property on Message items

### DIFF
--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -1189,6 +1189,9 @@ pub struct Message {
 
     #[xml_struct(ns_prefix = "t")]
     pub conversation_id: Option<ItemId>,
+
+    #[xml_struct(ns_prefix = "t")]
+    pub references: Option<String>,
 }
 
 /// An extended MAPI property of an Exchange item or folder.


### PR DESCRIPTION
This is needed for https://bugzilla.mozilla.org/show_bug.cgi?id=1956601