### PR TITLE
Support server version headers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,4 +26,7 @@ pub enum Error {
     // relatively low.
     #[error("a fault occurred in the request")]
     RequestFault(Box<soap::Fault>),
+
+    #[error("unknown server version: {0}")]
+    UnknownServerVersion(String),
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,6 +15,7 @@ pub mod delete_folder;
 pub mod delete_item;
 pub mod get_folder;
 pub mod get_item;
+pub mod server_version;
 pub mod sync_folder_hierarchy;
 pub mod sync_folder_items;
 pub mod update_folder;

--- a/src/types/server_version.rs
+++ b/src/types/server_version.rs
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use serde::Deserialize;
+use xml_struct::XmlSerialize;
+
+use crate::Error;
+
+/// The Exchange Server version identifiers allowed in `RequestServerVersion`
+/// headers.
+///
+/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/requestserverversion#version-attribute-values>
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, XmlSerialize)]
+#[xml_struct(text)]
+pub enum ExchangeServerVersion {
+    Exchange2007,
+    Exchange2007_SP1,
+    Exchange2010,
+    Exchange2010_SP1,
+    Exchange2010_SP2,
+    Exchange2013,
+    Exchange2013_SP1,
+}
+
+/// Parses the provided string into a known version identifier.
+impl TryFrom<&str> for ExchangeServerVersion {
+    /// If the provided string could not be turned into a known version
+    /// identifier, [`Error::UnknownServerVersion`] is returned.
+    type Error = Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "Exchange2007" => Ok(ExchangeServerVersion::Exchange2007),
+            "Exchange2007_SP1" => Ok(ExchangeServerVersion::Exchange2007_SP1),
+            "Exchange2010" => Ok(ExchangeServerVersion::Exchange2010),
+            "Exchange2010_SP1" => Ok(ExchangeServerVersion::Exchange2010_SP1),
+            "Exchange2010_SP2" => Ok(ExchangeServerVersion::Exchange2010_SP2),
+            "Exchange2013" => Ok(ExchangeServerVersion::Exchange2013),
+            "Exchange2013_SP1" => Ok(ExchangeServerVersion::Exchange2013_SP1),
+
+            _ => Err(Error::UnknownServerVersion(value.to_owned())),
+        }
+    }
+}
+
+// While we don't strictly need this implementation for serialization
+// (`xml-struct` knows how to string-ify unit enum variants without additional
+// guidance), consumers can require it to persist the version associated with a
+// given server.
+impl From<ExchangeServerVersion> for String {
+    fn from(value: ExchangeServerVersion) -> Self {
+        match value {
+            ExchangeServerVersion::Exchange2007 => "Exchange2007",
+            ExchangeServerVersion::Exchange2007_SP1 => "Exchange2007_SP1",
+            ExchangeServerVersion::Exchange2010 => "Exchange2010",
+            ExchangeServerVersion::Exchange2010_SP1 => "Exchange2010_SP1",
+            ExchangeServerVersion::Exchange2010_SP2 => "Exchange2010_SP2",
+            ExchangeServerVersion::Exchange2013 => "Exchange2013",
+            ExchangeServerVersion::Exchange2013_SP1 => "Exchange2013_SP1",
+        }
+        .into()
+    }
+}
+
+/// The version information of the Exchange Server instance that generated
+/// the attached response.
+///
+/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/serverversioninfo>
+#[derive(Clone, Debug, Deserialize, XmlSerialize)]
+pub struct ServerVersionInfo {
+    #[xml_struct(attribute)]
+    #[serde(rename = "@MajorVersion")]
+    pub major_version: Option<String>,
+
+    #[xml_struct(attribute)]
+    #[serde(rename = "@MinorVersion")]
+    pub minor_version: Option<String>,
+
+    #[xml_struct(attribute)]
+    #[serde(rename = "@MajorBuildNumber")]
+    pub major_build_number: Option<String>,
+
+    #[xml_struct(attribute)]
+    #[serde(rename = "@MinorBuildNumber")]
+    pub minor_build_number: Option<String>,
+
+    #[xml_struct(attribute)]
+    #[serde(rename = "@Version")]
+    pub version: Option<String>,
+}

--- a/src/types/soap.rs
+++ b/src/types/soap.rs
@@ -7,20 +7,54 @@ use quick_xml::{
     Reader, Writer,
 };
 use serde::Deserialize;
+use xml_struct::XmlSerialize;
 
 use crate::{
-    types::sealed, Error, MessageXml, Operation, OperationResponse, ResponseCode, SOAP_NS_URI,
-    TYPES_NS_URI,
+    types::sealed, types::server_version, Error, MessageXml, Operation, OperationResponse,
+    ResponseCode, SOAP_NS_URI, TYPES_NS_URI,
 };
 
 mod de;
 use self::de::DeserializeEnvelope;
+
+use super::server_version::ExchangeServerVersion;
+
+/// An element that can be found in the `soap:Header` section of an request or a
+/// response.
+///
+/// See <https://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383497>
+//
+// Currently, request headers are represented as struct variants and response
+// headers are represented as tuple variants. Ideally we should use tuple
+// variants everywhere, but, right now, doing so for request headers would
+// remove their XML attributes due to
+// https://github.com/thunderbird/xml-struct-rs/issues/9
+#[derive(Clone, Debug, Deserialize, XmlSerialize)]
+#[xml_struct(variant_ns_prefix = "t")]
+#[non_exhaustive]
+pub enum SoapHeader {
+    /// The schema version targeted by the attached request.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/requestserverversion>
+    RequestServerVersion {
+        #[xml_struct(attribute)]
+        #[serde(rename = "@Version")]
+        version: ExchangeServerVersion,
+    },
+
+    /// The version information of the Exchange Server instance that generated
+    /// the attached response.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/serverversioninfo>s
+    ServerVersionInfo(server_version::ServerVersionInfo),
+}
 
 /// A SOAP envelope containing the body of an EWS operation or response.
 ///
 /// See <https://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383494>
 #[derive(Clone, Debug)]
 pub struct Envelope<B> {
+    pub headers: Vec<SoapHeader>,
     pub body: B,
 }
 
@@ -31,6 +65,7 @@ where
     /// Serializes the SOAP envelope as a complete XML document.
     pub fn as_xml_document(&self) -> Result<Vec<u8>, Error> {
         const SOAP_ENVELOPE: &str = "soap:Envelope";
+        const SOAP_HEADER: &str = "soap:Header";
         const SOAP_BODY: &str = "soap:Body";
 
         let mut writer = {
@@ -47,6 +82,11 @@ where
             BytesStart::new(SOAP_ENVELOPE)
                 .with_attributes([("xmlns:soap", SOAP_NS_URI), ("xmlns:t", TYPES_NS_URI)]),
         ))?;
+
+        // Write the SOAP headers.
+        self.headers
+            .serialize_as_element(&mut writer, SOAP_HEADER)?;
+
         writer.write_event(Event::Start(BytesStart::new(SOAP_BODY)))?;
 
         // Write the operation itself.
@@ -89,6 +129,7 @@ where
         let envelope: DeserializeEnvelope<B> = serde_path_to_error::deserialize(de)?;
 
         Ok(Envelope {
+            headers: envelope.header.inner,
             body: envelope.body,
         })
     }

--- a/src/types/soap.rs
+++ b/src/types/soap.rs
@@ -32,7 +32,7 @@ use super::server_version::ExchangeServerVersion;
 #[derive(Clone, Debug, Deserialize, XmlSerialize)]
 #[xml_struct(variant_ns_prefix = "t")]
 #[non_exhaustive]
-pub enum SoapHeader {
+pub enum Header {
     /// The schema version targeted by the attached request.
     ///
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/requestserverversion>
@@ -54,7 +54,7 @@ pub enum SoapHeader {
 /// See <https://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383494>
 #[derive(Clone, Debug)]
 pub struct Envelope<B> {
-    pub headers: Vec<SoapHeader>,
+    pub headers: Vec<Header>,
     pub body: B,
 }
 

--- a/src/types/soap/de.rs
+++ b/src/types/soap/de.rs
@@ -6,7 +6,7 @@ use std::marker::PhantomData;
 
 use serde::{de::Visitor, Deserialize, Deserializer};
 
-use crate::soap::SoapHeader;
+use crate::soap::Header;
 use crate::OperationResponse;
 
 /// A helper for deserialization of SOAP envelopes.
@@ -29,7 +29,7 @@ where
 #[derive(Deserialize)]
 pub struct SoapHeaders {
     #[serde(rename = "$value", default)]
-    pub inner: Vec<SoapHeader>,
+    pub inner: Vec<Header>,
 }
 
 fn deserialize_body<'de, D, T>(body: D) -> Result<T, D::Error>

--- a/src/types/soap/de.rs
+++ b/src/types/soap/de.rs
@@ -6,6 +6,7 @@ use std::marker::PhantomData;
 
 use serde::{de::Visitor, Deserialize, Deserializer};
 
+use crate::soap::SoapHeader;
 use crate::OperationResponse;
 
 /// A helper for deserialization of SOAP envelopes.
@@ -20,8 +21,15 @@ pub(super) struct DeserializeEnvelope<T>
 where
     T: OperationResponse,
 {
+    pub header: SoapHeaders,
     #[serde(deserialize_with = "deserialize_body")]
     pub body: T,
+}
+
+#[derive(Deserialize)]
+pub struct SoapHeaders {
+    #[serde(rename = "$value", default)]
+    pub inner: Vec<SoapHeader>,
 }
 
 fn deserialize_body<'de, D, T>(body: D) -> Result<T, D::Error>


### PR DESCRIPTION
This change adds some types to the `soap` module to support SOAP headers, as well as a couple of types to represent SOAP headers related to Exchange Server version handling (for [bug 1964652](https://bugzilla.mozilla.org/show_bug.cgi?id=1964652)).

I wasn't entirely sure how to structure SOAP headers, so let me know if there's any improvement that could be made there. Although it's worth noting https://github.com/thunderbird/xml-struct-rs/issues/9 limits the ways to represent request headers.