### PR TITLE
Improve the readme file with documentation and bug tracker location

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,20 @@ This rust crate holds types that represent data structures and operations for
 the Exchange Web Services API, as well as the necessary infrastructure to
 serialize and deserialize them to/from XML.
 
+## Documentation
+
+The Cargo documentation for this repository is not currently hosted online. It
+can be accessed locally after cloning this repository and generating it:
+
+```bash
+git clone https://github.com/thunderbird/ews-rs.git
+cd ews-rs
+cargo doc
+```
+
+## Report issues
+
+The GitHub issue tracker for this repository is disabled to help us handle
+EWS-related Thunderbird-adjacent bugs more easily. To report an issue or file a
+feature request for this crate, please do so on Bugzilla
+[here](https://bugzilla.mozilla.org/enter_bug.cgi?product=MailNews%20Core&component=Networking:%20Exchange).


### PR DESCRIPTION
Now that we have disabled the issue tracker for this repository, we should tell users where to file bugs.