### PR TITLE
Derive `Ord` and `PartialOrd` for `ExchangeServerVersion`

### DIFF
--- a/src/types/server_version.rs
+++ b/src/types/server_version.rs
@@ -12,7 +12,7 @@ use crate::Error;
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/requestserverversion#version-attribute-values>
 #[allow(non_camel_case_types)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, XmlSerialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize, XmlSerialize)]
 #[xml_struct(text)]
 pub enum ExchangeServerVersion {
     Exchange2007,


### PR DESCRIPTION
I was reviewing https://phabricator.services.mozilla.com/D251633 and thought this could make comparing versions easier.