### PR TITLE
implement `Deserialize` for `MessageXml`

### DIFF
--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -8,6 +8,9 @@ use serde::{Deserialize, Deserializer};
 use time::format_description::well_known::Iso8601;
 use xml_struct::XmlSerialize;
 
+pub mod message_xml;
+pub use self::message_xml::MessageXml;
+
 pub(crate) const MESSAGES_NS_URI: &str =
     "http://schemas.microsoft.com/exchange/services/2006/messages";
 pub(crate) const SOAP_NS_URI: &str = "http://schemas.xmlsoap.org/soap/envelope/";
@@ -1636,25 +1639,6 @@ pub struct InternetMessageHeader {
     #[serde(rename = "$text")]
     #[xml_struct(flatten)]
     pub value: String,
-}
-
-/// Structured data for diagnosing or responding to an EWS error.
-///
-/// Because the possible contents of this field are not documented, any XML
-/// contained in the field is provided as text for debugging purposes. Known
-/// fields which are relevant for programmatic error responses should be
-/// provided as additional fields of this structure.
-///
-/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/messagexml>
-#[derive(Clone, Debug, PartialEq)]
-#[non_exhaustive]
-pub struct MessageXml {
-    /// A text representation of the contents of the field.
-    pub content: String,
-
-    /// The duration in milliseconds to wait before making additional requests
-    /// if the server is throttling operations.
-    pub back_off_milliseconds: Option<usize>,
 }
 
 #[cfg(test)]

--- a/src/types/common/message_xml.rs
+++ b/src/types/common/message_xml.rs
@@ -1,0 +1,174 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+use serde::de::{self, MapAccess, Visitor};
+use serde::{Deserialize, Deserializer};
+use std::fmt;
+use std::marker::PhantomData;
+
+/// Semi-structured data for diagnosing or responding to an EWS error.
+///
+/// Because the possible contents of this field are not documented, this may not
+/// precisely represent all potential messages. Known fields that are relevant
+/// for programmatic error responses should be provided as additional variants
+/// of this enum. All other responses are represented via the `Other` variant.
+///
+/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/messagexml>
+// There appears to be two observed structurings of MessageXml elements:
+// - one or more Value elements differentiated by Name attribute: <t:Value Name="Foo">value</t:Value>
+// - one or more directly tagged elements: <t:Foo>value</t:Foo>
+// In all observed samples, these are never mixed, and are only one layer
+// deep. Because we have to distinguish types based on the tag *and* an
+// attribute, most new variants will require manual Deserialize implementations,
+// though quick_xml's impl_deserialize_for_internally_tagged_enum may work for
+// this one day.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(untagged)]
+#[non_exhaustive]
+pub enum MessageXml {
+    ServerBusy(ServerBusy),
+    /// Any elements not handled above, for debugging and troubleshooting purposes.
+    // `Other` *must* come last, since it will match any single-layer XML.
+    Other(MessageXmlElements),
+}
+
+/// One of the two observed kinds of MessageXml elements: a Value named via the @Name attribute.
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+pub struct MessageXmlValue {
+    #[serde(rename = "@Name")]
+    pub name: String,
+    #[serde(rename = "$text")]
+    pub value: String,
+}
+
+/// One of the two observed kinds of MessageXml elements: a tag with a single text value.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MessageXmlTagged {
+    pub name: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MessageXmlElements {
+    pub elements: Vec<MessageXmlElement>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MessageXmlElement {
+    MessageXmlTagged(MessageXmlTagged),
+    MessageXmlValue(MessageXmlValue),
+}
+
+/// Data associated with a [`ResponseCode::ErrorServerBusy`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct ServerBusy {
+    /// The duration in milliseconds to wait before making additional requests.
+    pub back_off_milliseconds: u32,
+}
+
+struct ServerBusyVisitor {
+    marker: PhantomData<fn() -> ServerBusy>,
+}
+
+impl ServerBusyVisitor {
+    fn new() -> Self {
+        ServerBusyVisitor {
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<'de> Visitor<'de> for ServerBusyVisitor {
+    type Value = ServerBusy;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a Value element with Name=BackOffMilliseconds and an integer value")
+    }
+
+    fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
+    where
+        M: MapAccess<'de>,
+    {
+        while let Some(name) = access.next_key::<String>()? {
+            if name.as_str() != "Value" {
+                continue;
+            }
+            let value = access.next_value::<MessageXmlValue>()?;
+            if value.name.as_str() == "BackOffMilliseconds" {
+                let ms = value.value.parse::<u32>().map_err(de::Error::custom)?;
+                return Ok(ServerBusy {
+                    back_off_milliseconds: ms,
+                });
+            }
+        }
+
+        Err(de::Error::custom("no BackOffMilliseconds field"))
+    }
+}
+
+impl<'de> Deserialize<'de> for ServerBusy {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_map(ServerBusyVisitor::new())
+    }
+}
+
+struct MessageXmlElementsVisitor {
+    marker: PhantomData<fn() -> MessageXmlElements>,
+}
+
+impl MessageXmlElementsVisitor {
+    fn new() -> Self {
+        MessageXmlElementsVisitor {
+            marker: PhantomData,
+        }
+    }
+}
+
+/// An internal helper type used in the [`MessageXmlElementsVisitor`] to extract the
+/// text of an element while discarding the [`TYPES_NS_URI`] XML namespace declaration.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+enum Text {
+    #[serde(rename = "$text")]
+    Text(String),
+    #[serde(rename = "http://schemas.microsoft.com/exchange/services/2006/types")]
+    TypesNsDeclaration,
+}
+
+impl<'de> Visitor<'de> for MessageXmlElementsVisitor {
+    type Value = MessageXmlElements;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("non-recursive XML elements with @Name or no attributes")
+    }
+
+    fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
+    where
+        M: MapAccess<'de>,
+    {
+        let mut elements = vec![];
+
+        while let Some(name) = access.next_key::<String>()? {
+            if name.as_str() == "Value" {
+                let element = access.next_value::<MessageXmlValue>()?;
+                elements.push(MessageXmlElement::MessageXmlValue(element));
+            } else if let Text::Text(value) = access.next_value::<Text>()? {
+                let element = MessageXmlTagged { name, value };
+                elements.push(MessageXmlElement::MessageXmlTagged(element));
+            }
+        }
+
+        Ok(MessageXmlElements { elements })
+    }
+}
+
+impl<'de> Deserialize<'de> for MessageXmlElements {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_map(MessageXmlElementsVisitor::new())
+    }
+}

--- a/src/types/soap.rs
+++ b/src/types/soap.rs
@@ -2,9 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use de::EnvelopeContent;
 use quick_xml::{
     events::{BytesDecl, BytesEnd, BytesStart, Event},
-    Reader, Writer,
+    Writer,
 };
 use serde::Deserialize;
 use xml_struct::XmlSerialize;
@@ -106,20 +107,6 @@ where
 {
     /// Populates an [`Envelope`] from raw XML.
     pub fn from_xml_document(document: &[u8]) -> Result<Self, Error> {
-        // The body of an envelope can contain a fault, indicating an error with
-        // a request. We want to parse that and return it as the `Err` portion
-        // of a result. However, Microsoft includes a field in their fault
-        // responses called `MessageXml` which is explicitly documented as
-        // containing `xs:any`, meaning there is no documented schema for its
-        // contents. However, it may contain details relevant for debugging, so
-        // we want to capture it. Since we don't know what it contains, we
-        // settle for capturing it as XML text, but serde doesn't give us a nice
-        // way of doing that, so we perform this step separately.
-        let fault = extract_maybe_fault(document)?;
-        if let Some(fault) = fault {
-            return Err(Error::RequestFault(Box::new(fault)));
-        }
-
         let de = &mut quick_xml::de::Deserializer::from_reader(document);
 
         // `serde_path_to_error` ensures that we get sufficient information to
@@ -128,270 +115,16 @@ where
         // the context within the structure.
         let envelope: DeserializeEnvelope<B> = serde_path_to_error::deserialize(de)?;
 
-        Ok(Envelope {
-            headers: envelope.header.inner,
-            body: envelope.body,
-        })
-    }
-}
-
-/// Builds a structured representation of the SOAP fault contained in an
-/// [`Envelope`]-containing XML document, if any.
-///
-/// # Errors
-///
-/// An error will be returned if the input is not a valid XML document or if the
-/// document's encoding is not supported.
-fn extract_maybe_fault(document: &[u8]) -> Result<Option<Fault>, Error> {
-    let mut reader = ScopedReader::from_bytes(document);
-
-    // Any fault in the response will always be contained within the body of the
-    // SOAP envelope.
-    let mut envelope_reader = reader
-        .maybe_get_subreader_for_element("Envelope")?
-        .ok_or_else(|| unexpected_response(document))?;
-    let mut body_reader = envelope_reader
-        .maybe_get_subreader_for_element("Body")?
-        .ok_or_else(|| unexpected_response(document))?;
-
-    let fault_reader = body_reader.maybe_get_subreader_for_element("Fault")?;
-    let fault = if let Some(mut reader) = fault_reader {
-        let mut fault_code = None;
-        let mut fault_string = None;
-        let mut fault_actor = None;
-        let mut detail = None;
-
-        while let Some((name, subreader)) = reader.maybe_get_next_subreader()? {
-            match name.as_slice() {
-                b"faultcode" => {
-                    fault_code.replace(subreader.to_string()?);
-                }
-
-                b"faultstring" => {
-                    fault_string.replace(subreader.to_string()?);
-                }
-
-                b"faultactor" => {
-                    fault_actor.replace(subreader.to_string()?);
-                }
-
-                b"detail" => {
-                    detail.replace(parse_detail(subreader)?);
-                }
-
-                _ => {
-                    // Hitting this implies that Microsoft is breaking the SOAP
-                    // spec. We don't want to error and lose the other error
-                    // information we're looking for, but we should log so we
-                    // know it happened.
-                    log::warn!(
-                        "encountered unexpected element {} in soap:Fault containing body `{}'",
-                        subreader.reader.decoder().decode(&name)?,
-                        subreader.to_string()?
-                    )
-                }
-            }
+        match envelope.body {
+            EnvelopeContent::Body(body) => Ok(Envelope {
+                headers: envelope
+                    .header
+                    .expect("all non-fault responses should have headers")
+                    .inner,
+                body,
+            }),
+            EnvelopeContent::Fault(fault) => Err(Error::RequestFault(Box::new(fault))),
         }
-
-        // The SOAP spec requires that `faultcode` and `faultstring` be present.
-        // `faultactor` and `detail` are optional.
-        let fault_code = fault_code.ok_or_else(|| unexpected_response(document))?;
-        let fault_string = fault_string.ok_or_else(|| unexpected_response(document))?;
-
-        Some(Fault {
-            fault_code,
-            fault_string,
-            fault_actor,
-            detail,
-        })
-    } else {
-        None
-    };
-
-    Ok(fault)
-}
-
-/// Deserializes the contents of a `<detail>` element.
-fn parse_detail(mut reader: ScopedReader) -> Result<FaultDetail, Error> {
-    let mut detail = FaultDetail::default();
-
-    while let Some((name, subreader)) = reader.maybe_get_next_subreader()? {
-        match name.as_slice() {
-            b"ResponseCode" => {
-                // This is a hack to avoid an explicit `TryFrom` impl for
-                // `ResponseCode` and to reuse existing machinery/error types.
-                #[derive(Deserialize)]
-                struct ResponseCodeFrame {
-                    #[serde(rename = "ResponseCode")]
-                    response_code: ResponseCode,
-                }
-
-                // `quick_xml` requires us to have some sort of element around
-                // the text to be deserialized or it fails.
-                let frame_text = format!(
-                    "<root><ResponseCode>{}</ResponseCode></root>",
-                    subreader.to_string()?
-                );
-                let de = &mut quick_xml::de::Deserializer::from_reader(frame_text.as_bytes());
-                let frame: ResponseCodeFrame = serde_path_to_error::deserialize(de)?;
-
-                detail.response_code.replace(frame.response_code);
-            }
-
-            b"Message" => {
-                detail.message.replace(subreader.to_string()?);
-            }
-
-            b"MessageXml" => {
-                detail.message_xml.replace(parse_message_xml(subreader)?);
-            }
-
-            // Because the EWS documentation does not cover the contents of the
-            // `detail` field, we're limited to deserializing the field's we've
-            // already encountered. We want to be able to capture any fields we
-            // _don't_ know about as well, though.
-            _ => {
-                // If we've already stored a copy of the full content, we don't
-                // need to replace it.
-                if detail.content.is_none() {
-                    detail.content.replace(reader.to_string()?);
-                }
-            }
-        }
-    }
-
-    Ok(detail)
-}
-
-/// Deserializes the contents of a `<MessageXml>` element.
-fn parse_message_xml(mut reader: ScopedReader) -> Result<MessageXml, Error> {
-    let back_off_milliseconds = loop {
-        // We can't use the subreader methods here without some adaptation, as
-        // we need the `BytesStart` value for reading attributes.
-        match reader.reader.read_event()? {
-            Event::Start(start) => {
-                if start.local_name().as_ref() == b"Value" {
-                    let is_back_off = start.attributes().any(|attr_result| match attr_result {
-                        Ok(attr) => {
-                            attr.key.local_name().as_ref() == b"Name"
-                                && attr.value.as_ref() == b"BackOffMilliseconds"
-                        }
-                        Err(_) => false,
-                    });
-
-                    if is_back_off {
-                        let text = reader.reader.read_text(start.name())?;
-                        if let Ok(value) = text.parse::<usize>() {
-                            break Some(value);
-                        }
-                    }
-                }
-            }
-
-            Event::Eof => break None,
-
-            _ => continue,
-        }
-    };
-
-    Ok(MessageXml {
-        content: reader.to_string()?,
-        back_off_milliseconds,
-    })
-}
-
-/// Creates an `UnexpectedResponse` error from the provided XML bytes.
-fn unexpected_response(document: &[u8]) -> Error {
-    Error::UnexpectedResponse(Vec::from(document))
-}
-
-/// An XML reader interface for the contents of single nodes.
-///
-/// The intent of this interface is to provide a convenient means of processing
-/// XML documents without deep nesting by guaranteeing that only the contents of
-/// a single XML node and its children are processed.
-struct ScopedReader<'content> {
-    /// An event-based reader interface for low-level processing.
-    reader: Reader<&'content [u8]>,
-
-    /// The bytes provided to the reader interface.
-    // quick-xml may not retain a reference to the full content provided to it,
-    // so we need to maintain our own.
-    content: &'content [u8],
-}
-
-impl<'content> ScopedReader<'content> {
-    /// Creates a new reader from bytes representing a portion of an XML
-    /// document.
-    fn from_bytes(content: &'content [u8]) -> Self {
-        Self {
-            reader: Reader::from_reader(content),
-            content,
-        }
-    }
-
-    /// Gets a new reader representing the contents of the next element
-    /// contained within the current reader with a matching name, if any.
-    ///
-    /// The name provided for the element must be the local name, i.e. the name
-    /// of the element without any namespace prefix.
-    fn maybe_get_subreader_for_element(&mut self, local_name: &str) -> Result<Option<Self>, Error> {
-        loop {
-            match self.reader.read_event()? {
-                Event::Start(start) => {
-                    if start.local_name().as_ref() == local_name.as_bytes() {
-                        return self.get_subreader_from_start(&start).map(Some);
-                    }
-                }
-
-                Event::Eof => break,
-
-                _ => continue,
-            }
-        }
-
-        Ok(None)
-    }
-
-    /// Gets a new reader representing the contents of the next element found
-    /// within the current reader, if any, as well as the local name of that
-    /// element.
-    fn maybe_get_next_subreader(&mut self) -> Result<Option<(Vec<u8>, Self)>, Error> {
-        loop {
-            match self.reader.read_event()? {
-                Event::Start(start) => {
-                    let reader = self.get_subreader_from_start(&start)?;
-                    let local_name = start.local_name();
-
-                    return Ok(Some((local_name.as_ref().to_owned(), reader)));
-                }
-
-                Event::Eof => break,
-
-                _ => continue,
-            }
-        }
-
-        Ok(None)
-    }
-
-    /// Gets a new reader representing the contents of the element specified by
-    /// the element start event provided.
-    fn get_subreader_from_start(&mut self, start: &BytesStart<'content>) -> Result<Self, Error> {
-        let span = self.reader.read_to_end(start.name())?;
-        let content = &self.content[span];
-
-        // Notably, in doing this, we throw away any encoding information we may
-        // have had from the original reader. However, Microsoft _appears_ to
-        // send all responses as UTF-8. We'll encounter bigger problems
-        // elsewhere if we run into a non-UTF-8 document, most notably that we
-        // currently don't enable the `encoding` feature for quick-xml.
-        Ok(Self::from_bytes(content))
-    }
-
-    /// Gets a string representation of the contents of the current reader.
-    fn to_string(&self) -> Result<String, Error> {
-        Ok(self.reader.decoder().decode(self.content)?.into_owned())
     }
 }
 
@@ -399,7 +132,7 @@ impl<'content> ScopedReader<'content> {
 /// request.
 ///
 /// See <https://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383507>
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct Fault {
     /// An error code indicating the fault in the original request.
     // While `faultcode` is defined in the SOAP spec as a `QName`, we avoid
@@ -407,14 +140,14 @@ pub struct Fault {
     // allow for containing a string representation. We could use the `QName`
     // type to parse the contents of the field and store them in our own type if
     // we found value in this field beyond debug output.
-    pub fault_code: String,
+    pub faultcode: String,
 
     /// A human-readable description of the error.
-    pub fault_string: String,
+    pub faultstring: String,
 
     /// A URI indicating the SOAP actor responsible for the error.
     // This may be unused for EWS.
-    pub fault_actor: Option<String>,
+    pub faultactor: Option<String>,
 
     /// Clarifying information about EWS-specific errors.
     pub detail: Option<FaultDetail>,
@@ -423,7 +156,8 @@ pub struct Fault {
 /// EWS-specific details regarding a SOAP fault.
 ///
 /// This element is not documented in the EWS reference.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "PascalCase")]
 #[non_exhaustive]
 pub struct FaultDetail {
     /// An error code indicating the nature of the issue.
@@ -455,7 +189,13 @@ pub struct FaultDetail {
 mod tests {
     use serde::Deserialize;
 
-    use crate::{types::sealed::EnvelopeBodyContents, Error, OperationResponse, ResponseCode};
+    use crate::{
+        types::common::message_xml::{
+            MessageXmlElement, MessageXmlElements, MessageXmlTagged, MessageXmlValue, ServerBusy,
+        },
+        types::sealed::EnvelopeBodyContents,
+        Error, MessageXml, OperationResponse, ResponseCode,
+    };
 
     use super::Envelope;
 
@@ -491,18 +231,22 @@ mod tests {
         );
     }
 
+    #[derive(Clone, Debug, Deserialize)]
+    struct Foo;
+
+    impl OperationResponse for Foo {}
+
+    impl EnvelopeBodyContents for Foo {
+        fn name() -> &'static str {
+            "Foo"
+        }
+    }
+
     #[test]
     fn deserialize_envelope_with_schema_fault() {
-        #[derive(Clone, Debug, Deserialize)]
-        struct Foo;
-
-        impl OperationResponse for Foo {}
-
-        impl EnvelopeBodyContents for Foo {
-            fn name() -> &'static str {
-                "Foo"
-            }
-        }
+        // This test will require significant changes if we add SchemaValidation
+        // to the MessageXml enum. Right now, it's testing an "unknown" tagged
+        // element variant with multiple elements.
 
         // This XML is drawn from testing data for `evolution-ews`.
         let xml = r#"<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Body><s:Fault><faultcode xmlns:a="http://schemas.microsoft.com/exchange/services/2006/types">a:ErrorSchemaValidation</faultcode><faultstring xml:lang="en-US">The request failed schema validation: The 'Id' attribute is invalid - The value 'invalidparentid' is invalid according to its datatype 'http://schemas.microsoft.com/exchange/services/2006/types:DistinguishedFolderIdNameType' - The Enumeration constraint failed.</faultstring><detail><e:ResponseCode xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">ErrorSchemaValidation</e:ResponseCode><e:Message xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">The request failed schema validation.</e:Message><t:MessageXml xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><t:LineNumber>2</t:LineNumber><t:LinePosition>630</t:LinePosition><t:Violation>The 'Id' attribute is invalid - The value 'invalidparentid' is invalid according to its datatype 'http://schemas.microsoft.com/exchange/services/2006/types:DistinguishedFolderIdNameType' - The Enumeration constraint failed.</t:Violation></t:MessageXml></detail></s:Fault></s:Body></s:Envelope>"#;
@@ -512,12 +256,12 @@ mod tests {
 
         if let Error::RequestFault(fault) = err {
             assert_eq!(
-                fault.fault_code, "a:ErrorSchemaValidation",
+                fault.faultcode, "a:ErrorSchemaValidation",
                 "fault code should match original document"
             );
-            assert_eq!(fault.fault_string, "The request failed schema validation: The 'Id' attribute is invalid - The value 'invalidparentid' is invalid according to its datatype 'http://schemas.microsoft.com/exchange/services/2006/types:DistinguishedFolderIdNameType' - The Enumeration constraint failed.", "fault string should match original document");
+            assert_eq!(fault.faultstring, "The request failed schema validation: The 'Id' attribute is invalid - The value 'invalidparentid' is invalid according to its datatype 'http://schemas.microsoft.com/exchange/services/2006/types:DistinguishedFolderIdNameType' - The Enumeration constraint failed.", "fault string should match original document");
             assert!(
-                fault.fault_actor.is_none(),
+                fault.faultactor.is_none(),
                 "fault actor should not be present"
             );
 
@@ -534,10 +278,109 @@ mod tests {
             );
 
             let message_xml = detail.message_xml.expect("message XML should be present");
-            assert_eq!(&message_xml.content, "<t:LineNumber>2</t:LineNumber><t:LinePosition>630</t:LinePosition><t:Violation>The 'Id' attribute is invalid - The value 'invalidparentid' is invalid according to its datatype 'http://schemas.microsoft.com/exchange/services/2006/types:DistinguishedFolderIdNameType' - The Enumeration constraint failed.</t:Violation>", "message XML content should contain full body of MessageXml tag");
+
+            let MessageXml::Other(elements) = message_xml else {
+                panic!("this message XML should only have bare tags")
+            };
+            let expected = MessageXmlElements {
+                elements: vec![
+                    MessageXmlElement::MessageXmlTagged(MessageXmlTagged {
+                        name: "LineNumber".to_string(),
+                        value: "2".to_string()
+                    }),
+                    MessageXmlElement::MessageXmlTagged(MessageXmlTagged {
+                        name: "LinePosition".to_string(),
+                        value: "630".to_string()
+                    }),
+                    MessageXmlElement::MessageXmlTagged(MessageXmlTagged {
+                        name: "Violation".to_string(),
+                        value: "The 'Id' attribute is invalid - The value 'invalidparentid' is invalid according to its datatype 'http://schemas.microsoft.com/exchange/services/2006/types:DistinguishedFolderIdNameType' - The Enumeration constraint failed.".to_string()
+                    })
+                ]
+            };
+            assert_eq!(
+                elements, expected,
+                "message XML should list all tags in order"
+            );
+        } else {
+            panic!("error should be request fault, got: {err:?}");
+        }
+    }
+
+    #[test]
+    fn deserialize_envelope_with_connection_count_fault() {
+        // This test will require significant changes if we add
+        // ExceededConnectionCount to the MessageXml enum. Right now, it's
+        // testing an "unknown" Value variant with multiple Values.
+
+        // This XML is based on https://github.com/OfficeDev/ews-managed-api/issues/293#issuecomment-1506483638
+        let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+  <s:Body>
+    <s:Fault>
+      <faultcode xmlns:a="http://schemas.microsoft.com/exchange/services/2006/types">a:ErrorExceededConnectionCount</faultcode>
+      <faultstring xml:lang="en-US">You have exceeded the available concurrent connections for your account.  Try again once your other requests have completed.</faultstring>
+      <detail>
+        <e:ResponseCode xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">ErrorExceededConnectionCount</e:ResponseCode>
+        <e:Message xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">You have exceeded the available concurrent connections for your account.  Try again once your other requests have completed.</e:Message>
+        <t:MessageXml xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+          <t:Value Name="Policy">MaxConcurrency</t:Value>
+          <t:Value Name="MaxConcurrencyLimit">27</t:Value>
+          <t:Value Name="ErrorMessage">This operation exceeds the throttling budget for policy part 'MaxConcurrency', policy value '27',  Budget type: 'Ews'.  Suggested backoff time 0 ms.</t:Value>
+        </t:MessageXml>
+      </detail>
+    </s:Fault>
+  </s:Body>
+</s:Envelope>"#;
+
+        let err = <Envelope<Foo>>::from_xml_document(xml.as_bytes())
+            .expect_err("should return error when body contains fault");
+
+        // The testing here isn't as thorough as the invalid schema test due to
+        // the contrived nature of the example. We don't want it to break if we
+        // can get real-world examples.
+        if let Error::RequestFault(fault) = err {
+            assert_eq!(
+                fault.faultcode, "a:ErrorExceededConnectionCount",
+                "fault code should match original document"
+            );
             assert!(
-                message_xml.back_off_milliseconds.is_none(),
-                "back off milliseconds should not be present"
+                fault.faultactor.is_none(),
+                "fault actor should not be present"
+            );
+
+            let detail = fault.detail.expect("fault detail should be present");
+            assert_eq!(
+                detail.response_code,
+                Some(ResponseCode::ErrorExceededConnectionCount),
+                "response code should match original document"
+            );
+
+            let message_xml = detail.message_xml.expect("message XML should be present");
+
+            let MessageXml::Other(elements) = message_xml else {
+                panic!("this message XML should only have bare tags")
+            };
+
+            let expected = MessageXmlElements {
+                elements: vec![
+                    MessageXmlElement::MessageXmlValue(MessageXmlValue {
+                        name: "Policy".to_string(),
+                        value: "MaxConcurrency".to_string()
+                    }),
+                    MessageXmlElement::MessageXmlValue(MessageXmlValue {
+                        name: "MaxConcurrencyLimit".to_string(),
+                        value: "27".to_string()
+                    }),
+                    MessageXmlElement::MessageXmlValue(MessageXmlValue {
+                        name: "ErrorMessage".to_string(),
+                        value: "This operation exceeds the throttling budget for policy part 'MaxConcurrency', policy value '27',  Budget type: 'Ews'.  Suggested backoff time 0 ms.".to_string()
+                    })
+                ]
+            };
+            assert_eq!(
+                elements, expected,
+                "message XML should list all tags in order"
             );
         } else {
             panic!("error should be request fault, got: {err:?}");
@@ -546,17 +389,6 @@ mod tests {
 
     #[test]
     fn deserialize_envelope_with_server_busy_fault() {
-        #[derive(Clone, Debug, Deserialize)]
-        struct Foo;
-
-        impl OperationResponse for Foo {}
-
-        impl EnvelopeBodyContents for Foo {
-            fn name() -> &'static str {
-                "Foo"
-            }
-        }
-
         // This XML is contrived based on what's known of the shape of
         // `ErrorServerBusy` responses. It should be replaced when we have
         // real-life examples.
@@ -570,11 +402,11 @@ mod tests {
         // can get real-world examples.
         if let Error::RequestFault(fault) = err {
             assert_eq!(
-                fault.fault_code, "a:ErrorServerBusy",
+                fault.faultcode, "a:ErrorServerBusy",
                 "fault code should match original document"
             );
             assert!(
-                fault.fault_actor.is_none(),
+                fault.faultactor.is_none(),
                 "fault actor should not be present"
             );
 
@@ -586,7 +418,13 @@ mod tests {
             );
 
             let message_xml = detail.message_xml.expect("message XML should be present");
-            assert_eq!(message_xml.back_off_milliseconds, Some(25));
+
+            assert_eq!(
+                message_xml,
+                MessageXml::ServerBusy(ServerBusy {
+                    back_off_milliseconds: 25
+                })
+            );
         } else {
             panic!("error should be request fault, got: {err:?}");
         }


### PR DESCRIPTION
This is an extensive change to how `MessageXml` works, and loses the ability to store the raw XML within the type (most attributes in particular will now be implicitly stripped, as will new fields in known types). This change allows `MessageXml` as a member in other types that derive `Deserialize`.

First half of addressing [Bug 1971330](https://bugzilla.mozilla.org/show_bug.cgi?id=1971330).

Feel free to point me down an entirely different approach, or delve into all the nits, this was in large part a learning exercise (serde *really* doesn't want you parsing unknown types). :)