### PR TITLE
Ignore attributes on soap bodies

### DIFF
--- a/src/types/get_folder.rs
+++ b/src/types/get_folder.rs
@@ -37,7 +37,7 @@ impl EnvelopeBodyContents for GetFolder {
 /// A response to a [`GetFolder`] request.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/getfolderresponse>
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct GetFolderResponse {
     pub response_messages: ResponseMessages,
@@ -54,7 +54,7 @@ impl EnvelopeBodyContents for GetFolderResponse {
 /// A collection of responses for individual entities within a request.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/responsemessages>
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct ResponseMessages {
     pub get_folder_response_message: Vec<GetFolderResponseMessage>,
@@ -63,7 +63,7 @@ pub struct ResponseMessages {
 /// A response to a request for an individual folder within a [`GetFolder`] operation.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/getfolderresponsemessage>
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct GetFolderResponseMessage {
     /// The status of the corresponding request, i.e. whether it succeeded or


### PR DESCRIPTION
Serde considers attributes as nested elements. So if the soap body tag has attributes on it, our parsing code fail because we expect the operation response to be the only element in there.