### PR TITLE
README.md nits

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,16 @@ cargo doc --open
 
 The GitHub issue tracker for this repository is disabled to help us handle
 EWS-related Thunderbird-adjacent bugs more easily. To report an issue or file a
-feature request for this crate, please do so on Bugzilla
-[here](https://bugzilla.mozilla.org/enter_bug.cgi?product=MailNews%20Core&component=Networking:%20Exchange).
+feature request for this crate, please do so in [Bugzilla under
+`Networking:Exchange`](https://bugzilla.mozilla.org/enter_bug.cgi?product=MailNews%20Core&component=Networking:%20Exchange).
 
 ## Minimum Supported Rust Version
 
-The `ews` crate follows the Firefox MSRV policy described
-[here](https://firefox-source-docs.mozilla.org/writing-rust-code/update-policy.html#minimum-supported-rust-version).
+The `ews` crate follows the [Firefox MSRV policy](https://firefox-source-docs.mozilla.org/writing-rust-code/update-policy.html#minimum-supported-rust-version).
 It is therefore safe to assume the crate's effective MSRV is the one matching
 the latest Firefox release.
 
 ## License
 
 The `ews` crate is available under the terms of the Mozilla Public License,
-version 2.0. See either our [LICENSE] file or [https://www.mozilla.org/en-US/MPL/2.0/].
+version 2.0. See either our [LICENSE](LICENSE) file or [https://www.mozilla.org/en-US/MPL/2.0/].


### PR DESCRIPTION
Very minor, but [best accessibility practices](https://www.w3.org/TR/WCAG10-HTML-TECHS/#link-text) are to avoid "here" links. Also fix the link to the license file for GitHub's rendering.