### PR TITLE
check docs in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
 
 jobs:
   build:
@@ -41,12 +42,17 @@ jobs:
       run: cargo build
 
     - name: Test project
-      run: cargo test --all
+      run: cargo test --workspace
 
     - name: Run clippy
       uses: giraffate/clippy-action@v1
       with:
         reporter: 'github-pr-check'
-        clippy_flags: --no-deps
+        clippy_flags: --no-deps --tests
         filter_mode: nofilter
         github_token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build docs
+      env:
+        RUSTDOCFLAGS: -D warnings
+      run: cargo doc --no-deps --workspace --document-private-items

--- a/src/types/common/message_xml.rs
+++ b/src/types/common/message_xml.rs
@@ -59,7 +59,7 @@ pub enum MessageXmlElement {
     MessageXmlValue(MessageXmlValue),
 }
 
-/// Data associated with a [`ResponseCode::ErrorServerBusy`].
+/// Data associated with a [`ResponseCode::ErrorServerBusy`](crate::ResponseCode::ErrorServerBusy).
 #[derive(Debug, Clone, PartialEq)]
 pub struct ServerBusy {
     /// The duration in milliseconds to wait before making additional requests.
@@ -128,7 +128,7 @@ impl MessageXmlElementsVisitor {
 }
 
 /// An internal helper type used in the [`MessageXmlElementsVisitor`] to extract the
-/// text of an element while discarding the [`TYPES_NS_URI`] XML namespace declaration.
+/// text of an element while discarding the [`TYPES_NS_URI`](crate::TYPES_NS_URI) XML namespace declaration.
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 enum Text {
     #[serde(rename = "$text")]


### PR DESCRIPTION
Realized I didn't check `cargo doc` after moving items to a new file in the last PR, which broke some links. This fixes that, and adds a few improvements to the CI to prevent that sort of mistake going forward.