### PR TITLE
Silence new lint in soap tests

### DIFF
--- a/ews/src/types/soap.rs
+++ b/ews/src/types/soap.rs
@@ -248,6 +248,7 @@ mod tests {
     /// A meaningless struct.
     #[derive(Clone, Debug, XmlSerialize)]
     #[operation_response(Bar)]
+    #[allow(dead_code)]
     struct Foo {}
 
     /// A meaningless struct.


### PR DESCRIPTION
We don't use the `Foo` struct, but we do use the derived `FooResponse`. Silencing this warning is cleaner than implementing all the required traits by hand.