### PR TITLE
Replace `name()`s with associated NAME constants.

### DIFF
--- a/ews/src/types/operations.rs
+++ b/ews/src/types/operations.rs
@@ -20,13 +20,11 @@ pub trait Operation: XmlSerialize + sealed::EnvelopeBodyContents + std::fmt::Deb
     /// operation.
     type Response: OperationResponse;
 
-    /// Gets the name of the operation.
+    /// The name of the operation.
     ///
     /// This is the same as the local part of the name of the XML element used
     /// to represent this option.
-    fn name(&self) -> &'static str {
-        <Self as sealed::EnvelopeBodyContents>::name()
-    }
+    const NAME: &'static str;
 }
 
 /// A marker trait for EWS operation responses.
@@ -56,8 +54,8 @@ pub trait OperationResponse:
 pub(super) mod sealed {
     /// A trait for structures which may appear in the body of a SOAP envelope.
     pub trait EnvelopeBodyContents {
-        /// Gets the name of the element enclosing the contents of this
-        /// structure when represented in XML.
-        fn name() -> &'static str;
+        /// The name of the element enclosing the contents of this structure
+        /// when represented in XML.
+        const NAME: &'static str;
     }
 }

--- a/ews/src/types/soap.rs
+++ b/ews/src/types/soap.rs
@@ -92,7 +92,7 @@ where
 
         // Write the operation itself.
         self.body
-            .serialize_as_element(&mut writer, <B as sealed::EnvelopeBodyContents>::name())?;
+            .serialize_as_element(&mut writer, <B as sealed::EnvelopeBodyContents>::NAME)?;
 
         writer.write_event(Event::End(BytesEnd::new(SOAP_BODY)))?;
         writer.write_event(Event::End(BytesEnd::new(SOAP_ENVELOPE)))?;
@@ -226,9 +226,7 @@ mod tests {
         }
 
         impl EnvelopeBodyContents for SomeStruct {
-            fn name() -> &'static str {
-                "Foo"
-            }
+            const NAME: &'static str = "Foo";
         }
 
         // This XML is contrived, with a custom structure defined in order to

--- a/ews/src/types/soap/de.rs
+++ b/ews/src/types/soap/de.rs
@@ -101,7 +101,7 @@ where
                 Some(name) => {
                     // We expect the body of the response to contain a single
                     // element with the name of the expected operation response.
-                    let expected = T::name();
+                    let expected = T::NAME;
                     if name != expected {
                         return Err(serde::de::Error::custom(format_args!(
                             "unknown element `{name}`, expected {expected}"

--- a/ews_proc_macros/src/lib.rs
+++ b/ews_proc_macros/src/lib.rs
@@ -27,12 +27,11 @@ See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-ref
 
         impl crate::Operation for #request_name {
             type Response = #response_name;
+            const NAME: &'static str = stringify!(#request_name);
         }
 
         impl crate::types::sealed::EnvelopeBodyContents for #request_name {
-            fn name() -> &'static str {
-                stringify!(#request_name)
-            }
+            const NAME: &'static str = stringify!(#request_name);
         }
 
         #response_doc_attr
@@ -53,9 +52,7 @@ See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-ref
         }
 
         impl crate::types::sealed::EnvelopeBodyContents for #response_name {
-            fn name() -> &'static str {
-                stringify!(#response_name)
-            }
+            const NAME: &'static str = stringify!(#response_name);
         }
     };
 


### PR DESCRIPTION
This presumably optimizes into the same thing, but using associated constants removes a layer of indirection and allows us to use the name in more places (notably, as compile-time constants in other types or methods).