### PR TITLE
Implement Operation and EnvelopeBodyContents for &T

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 [[package]]
 name = "xml_struct"
 version = "0.1.0"
-source = "git+https://github.com/thunderbird/xml-struct-rs.git?rev=b010f262a2a7ad4ad8033096de3f0c599a448b97#b010f262a2a7ad4ad8033096de3f0c599a448b97"
+source = "git+https://github.com/thunderbird/xml-struct-rs.git?rev=9ebff0dfc395f417bef0e7dca9b1fceb25cea2e3#9ebff0dfc395f417bef0e7dca9b1fceb25cea2e3"
 dependencies = [
  "anyhow",
  "quick-xml",
@@ -202,7 +202,7 @@ dependencies = [
 [[package]]
 name = "xml_struct_derive"
 version = "0.1.0"
-source = "git+https://github.com/thunderbird/xml-struct-rs.git?rev=b010f262a2a7ad4ad8033096de3f0c599a448b97#b010f262a2a7ad4ad8033096de3f0c599a448b97"
+source = "git+https://github.com/thunderbird/xml-struct-rs.git?rev=9ebff0dfc395f417bef0e7dca9b1fceb25cea2e3#9ebff0dfc395f417bef0e7dca9b1fceb25cea2e3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 [[package]]
 name = "xml_struct"
 version = "0.1.0"
-source = "git+https://github.com/thunderbird/xml-struct-rs.git?rev=5b42f8d0d262bad2c2ff697d5a229b5187625022#5b42f8d0d262bad2c2ff697d5a229b5187625022"
+source = "git+https://github.com/thunderbird/xml-struct-rs.git?rev=b010f262a2a7ad4ad8033096de3f0c599a448b97#b010f262a2a7ad4ad8033096de3f0c599a448b97"
 dependencies = [
  "anyhow",
  "quick-xml",
@@ -202,7 +202,7 @@ dependencies = [
 [[package]]
 name = "xml_struct_derive"
 version = "0.1.0"
-source = "git+https://github.com/thunderbird/xml-struct-rs.git?rev=5b42f8d0d262bad2c2ff697d5a229b5187625022#5b42f8d0d262bad2c2ff697d5a229b5187625022"
+source = "git+https://github.com/thunderbird/xml-struct-rs.git?rev=b010f262a2a7ad4ad8033096de3f0c599a448b97#b010f262a2a7ad4ad8033096de3f0c599a448b97"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ews/Cargo.toml
+++ b/ews/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1.0.196", features = ["derive"] }
 serde_path_to_error = "0.1.11"
 thiserror = "1.0.57"
 time = { version = "0.3.36", features = ["formatting", "parsing", "serde"] }
-xml_struct = { git = "https://github.com/thunderbird/xml-struct-rs.git", rev = "5b42f8d0d262bad2c2ff697d5a229b5187625022", version = "0.1.0" }
+xml_struct = { git = "https://github.com/thunderbird/xml-struct-rs.git", rev = "b010f262a2a7ad4ad8033096de3f0c599a448b97", version = "0.1.0" }

--- a/ews/Cargo.toml
+++ b/ews/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1.0.196", features = ["derive"] }
 serde_path_to_error = "0.1.11"
 thiserror = "1.0.57"
 time = { version = "0.3.36", features = ["formatting", "parsing", "serde"] }
-xml_struct = { git = "https://github.com/thunderbird/xml-struct-rs.git", rev = "b010f262a2a7ad4ad8033096de3f0c599a448b97", version = "0.1.0" }
+xml_struct = { git = "https://github.com/thunderbird/xml-struct-rs.git", rev = "9ebff0dfc395f417bef0e7dca9b1fceb25cea2e3", version = "0.1.0" }

--- a/ews/src/types/operations.rs
+++ b/ews/src/types/operations.rs
@@ -27,6 +27,17 @@ pub trait Operation: XmlSerialize + sealed::EnvelopeBodyContents + std::fmt::Deb
     const NAME: &'static str;
 }
 
+// Blanket implementation for borrows, so the consumer does not need full
+// ownership of the struct instance to use the trait.
+impl<T> Operation for &T
+where
+    T: Operation,
+{
+    type Response = T::Response;
+
+    const NAME: &'static str = <T as Operation>::NAME;
+}
+
 /// A marker trait for EWS operation responses.
 ///
 /// Types implementing this trait may appear in responses from EWS after
@@ -57,5 +68,14 @@ pub(super) mod sealed {
         /// The name of the element enclosing the contents of this structure
         /// when represented in XML.
         const NAME: &'static str;
+    }
+
+    // Blanket implementation for borrows, so the consumer does not need full
+    // ownership of the struct instance to generate SOAP envelopes.
+    impl<T> EnvelopeBodyContents for &T
+    where
+        T: EnvelopeBodyContents,
+    {
+        const NAME: &'static str = T::NAME;
     }
 }


### PR DESCRIPTION
As part of the changes I'm working on for [bug 2010330](https://bugzilla.mozilla.org/show_bug.cgi?id=2010330), I'd like to make it possible for an `Envelope`'s body to be a reference on the operation struct instance rather than the instance itself. The reason is that I'm wrapping the instance into a struct that can be interacted with from the queue, and I'd like to be able to build the envelope without having to move the inner operation out of that struct.

Requires https://github.com/thunderbird/xml-struct-rs/pull/11