### PR TITLE
Make parsing DateTimes without a timezone non-breaking.

### DIFF
--- a/ews/src/types/common.rs
+++ b/ews/src/types/common.rs
@@ -605,18 +605,12 @@ impl RealItem {
 // `time` provides an `Option<OffsetDateTime>` deserializer, but it does not
 // work with map fields which may be omitted, as in our case.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum DateTime {
-    /// A date and time with a specific time zone.
-    WithTimeZone(OffsetDateTime),
-    /// A date and time without a specific time zone, which must therefore be
-    /// interpreted according to the respective rows of the "dateTime with no
-    /// time zone" column of the [EWS time zone
-    /// table](https://learn.microsoft.com/en-us/exchange/client-developer/exchange-web-services/time-zones-and-ews-in-exchange).
-    NoTimeZone(PrimitiveDateTime),
-}
+pub struct DateTime(pub OffsetDateTime);
 
-// We have to use a manual implementation because deriving from untagged enums
-// doesn't work with quick_xml.
+// While the docs say "Exchange will always include a time zone (either UTC or a
+// specific time zone) in the value", there appears to be a bug where
+// attachments will sometimes return a `LastModifiedTime` without a timezone.
+// This custom deserializer adds a fallback to parse such strings as UTC.
 impl<'de> Deserialize<'de> for DateTime {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -625,19 +619,18 @@ impl<'de> Deserialize<'de> for DateTime {
         let value = String::deserialize(deserializer)?;
 
         if let Ok(date_time) = OffsetDateTime::parse(&value, &Iso8601::DEFAULT) {
-            return Ok(Self::WithTimeZone(date_time));
+            Ok(Self(date_time))
+        } else {
+            PrimitiveDateTime::parse(&value, &Iso8601::DEFAULT)
+                .map(|date_time| Self(date_time.assume_utc()))
+                .map_err(de::Error::custom)
         }
-
-        PrimitiveDateTime::parse(&value, &Iso8601::DEFAULT)
-            .map(Self::NoTimeZone)
-            .map_err(de::Error::custom)
     }
 }
 
 impl XmlSerialize for DateTime {
     /// Serializes a `DateTime` as an XML text content node by formatting the
-    /// inner [`time::OffsetDateTime`] or [`time::PrimitiveDateTime`] as an ISO
-    /// 8601-compliant string.
+    /// inner [`time::OffsetDateTime`] as an ISO 8601-compliant string.
     fn serialize_child_nodes<W>(
         &self,
         writer: &mut quick_xml::Writer<W>,
@@ -645,14 +638,10 @@ impl XmlSerialize for DateTime {
     where
         W: std::io::Write,
     {
-        let time = match self {
-            Self::WithTimeZone(t) => t
-                .format(&Iso8601::DEFAULT)
-                .map_err(|err| xml_struct::Error::Value(err.into()))?,
-            Self::NoTimeZone(t) => t
-                .format(&Iso8601::DEFAULT)
-                .map_err(|err| xml_struct::Error::Value(err.into()))?,
-        };
+        let time = self
+            .0
+            .format(&Iso8601::DEFAULT)
+            .map_err(|err| xml_struct::Error::Value(err.into()))?;
 
         time.serialize_child_nodes(writer)
     }
@@ -1547,7 +1536,7 @@ mod tests {
                 content_id: None,
                 content_location: None,
                 size: None,
-                last_modified_time: Some(DateTime::WithTimeZone(
+                last_modified_time: Some(DateTime(
                     OffsetDateTime::parse("2026-06-26T17:54:39Z", &Iso8601::DEFAULT).unwrap(),
                 )),
                 is_inline: None,
@@ -1560,14 +1549,15 @@ mod tests {
     }
 
     #[test]
+    /// Attachments sometimes have a `last_modified_time` without a timezone.
     fn test_deserialize_date_time_without_time_zone() {
         let content = r#"<t:Message>
                 <t:DateTimeReceived>2026-06-26T17:54:39</t:DateTimeReceived>
             </t:Message>"#;
 
         let expected = Message {
-            date_time_received: Some(DateTime::NoTimeZone(
-                PrimitiveDateTime::parse("2026-06-26T17:54:39", &Iso8601::DEFAULT).unwrap(),
+            date_time_received: Some(DateTime(
+                OffsetDateTime::parse("2026-06-26T17:54:39Z", &Iso8601::DEFAULT).unwrap(),
             )),
             ..Default::default()
         };


### PR DESCRIPTION
Apologies for the followup, realized my mistake after I'd already merged.

It turns out my initial read was wrong, and that we should generally expect responses to have timezone information. This removes the API breakage introduced in 59bbd0c, at the cost of removing the ability to construct DateTimes without timezone information (which we probably shouldn't do, at least for now).

[The line I missed](https://learn.microsoft.com/en-us/exchange/client-developer/exchange-web-services/time-zones-and-ews-in-exchange#:~:text=Exchange%20will%20always%20include%20a%20time%20zone%20%28either%20UTC%20or%20a%20specific%20time%20zone%29%20in%20the%20value), after the table:

> Exchange will always include a time zone (either UTC or a specific time zone) in the value.

I did some digging and searching, and while there are plenty of examples of *requests* using the alternative, external timezone representations, the only example responses I can find without a timezone are in the [docs for attachments](https://learn.microsoft.com/en-us/exchange/client-developer/exchange-web-services/how-to-get-attachments-by-using-ews-in-exchange) (also where the reporter of [bug 2051022](https://bugzilla.mozilla.org/show_bug.cgi?id=2051022) encountered it), with the samples missing a timezone not really conforming to any of the exceptions in the table, implying it should be UTC.