### PR TITLE
Clean up tests.

### DIFF
--- a/ews/src/test_utils.rs
+++ b/ews/src/test_utils.rs
@@ -40,3 +40,10 @@ where
     let deserialized_data: T = serde_path_to_error::deserialize(&mut deserializer).unwrap();
     assert_eq!(deserialized_data, expected);
 }
+
+/// Turn the given XML into a single line, stripping leading whitespace.
+///
+/// Useful for turning readable XML into expected serialized output.
+pub fn minify_xml(xml: &str) -> String {
+    xml.lines().map(str::trim_ascii_start).collect()
+}

--- a/ews/src/types/common.rs
+++ b/ews/src/types/common.rs
@@ -1347,112 +1347,58 @@ mod tests {
 
     use super::*;
     use crate::{
-        test_utils::{assert_deserialized_content, assert_serialized_content},
+        test_utils::{assert_deserialized_content, assert_serialized_content, minify_xml},
         Error,
     };
 
-    /// Tests that an [`ArrayOfRecipients`] correctly serializes into XML. It
-    /// should serialize as multiple `<t:Mailbox>` elements, one per [`Recipient`].
+    /// Tests that an [`ArrayOfRecipients`] correctly serializes into XML and
+    /// back again. There should be a 1-to-1 correspondence between
+    /// `<t:Mailbox>` elements and [`Recipient`]s.
     #[test]
-    fn serialize_array_of_recipients() -> Result<(), Error> {
-        // Define the recipients to serialize.
-        let alice = Recipient {
-            mailbox: Mailbox {
-                name: Some("Alice Test".into()),
-                email_address: Some("alice@test.com".into()),
-                routing_type: None,
-                mailbox_type: None,
-                item_id: None,
-            },
-        };
+    fn test_array_of_recipients() -> Result<(), Error> {
+        let xml = minify_xml(
+            r#"
+            <Recipients>
+              <t:Mailbox>
+                <t:Name>Alice Test</t:Name>
+                <t:EmailAddress>alice@test.com</t:EmailAddress>
+              </t:Mailbox>
+              <t:Mailbox>
+                <t:Name>Bob Test</t:Name>
+                <t:EmailAddress>bob@test.com</t:EmailAddress>
+              </t:Mailbox>
+              <t:Mailbox>
+                <t:Name>Charlie Test</t:Name>
+              </t:Mailbox>
+            </Recipients>"#,
+        );
 
-        let bob = Recipient {
-            mailbox: Mailbox {
-                name: Some("Bob Test".into()),
-                email_address: Some("bob@test.com".into()),
-                routing_type: None,
-                mailbox_type: None,
-                item_id: None,
-            },
-        };
-
-        let charlie = Recipient {
-            mailbox: Mailbox {
-                name: Some("Charlie Test".into()),
-                email_address: None,
-                routing_type: None,
-                mailbox_type: None,
-                item_id: None,
-            },
-        };
-
-        let recipients = ArrayOfRecipients(vec![alice, bob, charlie]);
-
-        // Ensure the structure of the XML document is correct.
-        let expected = "<Recipients><t:Mailbox><t:Name>Alice Test</t:Name><t:EmailAddress>alice@test.com</t:EmailAddress></t:Mailbox><t:Mailbox><t:Name>Bob Test</t:Name><t:EmailAddress>bob@test.com</t:EmailAddress></t:Mailbox><t:Mailbox><t:Name>Charlie Test</t:Name></t:Mailbox></Recipients>";
-
-        assert_serialized_content(&recipients, "Recipients", expected);
-
-        Ok(())
-    }
-
-    /// Tests that deserializing a sequence of `<t:Mailbox>` XML elements
-    /// results in an [`ArrayOfRecipients`] with one [`Recipient`] per
-    /// `<t:Mailbox>` element.
-    #[test]
-    fn deserialize_array_of_recipients() -> Result<(), Error> {
-        // The raw XML to deserialize.
-        let xml = "<Recipients><t:Mailbox><t:Name>Alice Test</t:Name><t:EmailAddress>alice@test.com</t:EmailAddress></t:Mailbox><t:Mailbox><t:Name>Bob Test</t:Name><t:EmailAddress>bob@test.com</t:EmailAddress></t:Mailbox><t:Mailbox><t:Name>Charlie Test</t:Name></t:Mailbox></Recipients>";
-
-        // Deserialize the raw XML, with `serde_path_to_error` to help
-        // troubleshoot any issue.
-        let mut de = quick_xml::de::Deserializer::from_reader(xml.as_bytes());
-        let recipients: ArrayOfRecipients = serde_path_to_error::deserialize(&mut de)?;
-
-        // Ensure we have the right number of recipients in the resulting
-        // `ArrayOfRecipients`.
-        assert_eq!(recipients.0.len(), 3);
-
-        // Ensure the first recipient correctly has a name and address.
-        assert_eq!(
-            recipients.first().expect("no recipient at index 0"),
-            &Recipient {
+        let data = ArrayOfRecipients(vec![
+            Recipient {
                 mailbox: Mailbox {
                     name: Some("Alice Test".into()),
                     email_address: Some("alice@test.com".into()),
-                    routing_type: None,
-                    mailbox_type: None,
-                    item_id: None,
+                    ..Default::default()
                 },
-            }
-        );
-
-        // Ensure the second recipient correctly has a name and address.
-        assert_eq!(
-            recipients.get(1).expect("no recipient at index 1"),
-            &Recipient {
+            },
+            Recipient {
                 mailbox: Mailbox {
                     name: Some("Bob Test".into()),
                     email_address: Some("bob@test.com".into()),
-                    routing_type: None,
-                    mailbox_type: None,
-                    item_id: None,
+                    ..Default::default()
                 },
-            }
-        );
-
-        assert_eq!(
-            recipients.get(2).expect("no recipient at index 2"),
-            &Recipient {
+            },
+            Recipient {
                 mailbox: Mailbox {
                     name: Some("Charlie Test".into()),
-                    email_address: None,
-                    routing_type: None,
-                    mailbox_type: None,
-                    item_id: None
+                    ..Default::default()
                 },
-            }
-        );
+            },
+        ]);
+
+        assert_serialized_content(&data, "Recipients", &xml);
+
+        assert_deserialized_content(&xml, data);
 
         Ok(())
     }
@@ -1472,13 +1418,19 @@ mod tests {
             value: "data goes here".into(),
         };
 
-        let xml = r#"<ExtendedProperty><t:ExtendedFieldURI PropertyTag="0x007D" PropertyType="String"/><t:Value>data goes here</t:Value></ExtendedProperty>"#;
+        let xml = minify_xml(
+            r#"
+            <ExtendedProperty>
+              <t:ExtendedFieldURI PropertyTag="0x007D" PropertyType="String"/>
+              <t:Value>data goes here</t:Value>
+            </ExtendedProperty>"#,
+        );
 
         // Make sure data serializes into expected XML.
-        assert_serialized_content(&data, "ExtendedProperty", xml);
+        assert_serialized_content(&data, "ExtendedProperty", &xml);
 
         // Make sure XML deserializes into expected data.
-        assert_deserialized_content(xml, data);
+        assert_deserialized_content(&xml, data);
         Ok(())
     }
 
@@ -1486,17 +1438,16 @@ mod tests {
     #[test]
     fn test_attachment_parsing() {
         let item_attachment_xml = r#"
-<m:Attachments>
-  <t:ItemAttachment>
-    <t:AttachmentId Id="Ktum21o=" />
-    <t:Name>Attached Message Item</t:Name>
-    <t:ContentType>message/rfc822</t:ContentType>
-    <t:Message>
-      <t:ItemId Id="AAMkAd" ChangeKey="FwAAABY" />
-    </t:Message>
-  </t:ItemAttachment>
-</m:Attachments>
-"#;
+            <m:Attachments>
+              <t:ItemAttachment>
+                <t:AttachmentId Id="Ktum21o=" />
+                <t:Name>Attached Message Item</t:Name>
+                <t:ContentType>message/rfc822</t:ContentType>
+                <t:Message>
+                  <t:ItemId Id="AAMkAd" ChangeKey="FwAAABY" />
+                </t:Message>
+              </t:ItemAttachment>
+            </m:Attachments>"#;
 
         let data = Attachments {
             inner: vec![Attachment::ItemAttachment {
@@ -1525,16 +1476,15 @@ mod tests {
         assert_deserialized_content(item_attachment_xml, data);
 
         let file_attachment_xml = r#"
-<m:Attachments>
-  <t:FileAttachment>
-    <t:AttachmentId Id="AAAtAEFkbWluaX..."/>
-    <t:Name>SomeFile</t:Name>
-    <t:ContentType>message/rfc822</t:ContentType>
-    <t:Content>AQIDBAU=</t:Content>
-    <t:LastModifiedTime>2026-06-26T17:54:39Z</t:LastModifiedTime>
-  </t:FileAttachment>
-</m:Attachments>
-"#;
+            <m:Attachments>
+              <t:FileAttachment>
+                <t:AttachmentId Id="AAAtAEFkbWluaX..."/>
+                <t:Name>SomeFile</t:Name>
+                <t:ContentType>message/rfc822</t:ContentType>
+                <t:Content>AQIDBAU=</t:Content>
+                <t:LastModifiedTime>2026-06-26T17:54:39Z</t:LastModifiedTime>
+              </t:FileAttachment>
+            </m:Attachments>"#;
         let data = Attachments {
             inner: vec![Attachment::FileAttachment {
                 attachment_id: AttachmentId {
@@ -1561,8 +1511,9 @@ mod tests {
 
     #[test]
     fn test_deserialize_date_time_without_time_zone() {
-        let content = r#"<t:Message>
-                <t:DateTimeReceived>2026-06-26T17:54:39</t:DateTimeReceived>
+        let content = r#"
+            <t:Message>
+              <t:DateTimeReceived>2026-06-26T17:54:39</t:DateTimeReceived>
             </t:Message>"#;
 
         let expected = Message {
@@ -1594,12 +1545,13 @@ mod tests {
 
     #[test]
     fn test_deserialize_flag_status() {
-        let content = r#"<t:Message>
-                <t:Flag>
-                    <t:FlagStatus>Flagged</t:FlagStatus>
-                    <t:StartDate>2026-01-26T23:00:00Z</t:StartDate>
-                    <t:DueDate>2026-01-26T23:00:00Z</t:DueDate>
-                </t:Flag>
+        let content = r#"
+            <t:Message>
+              <t:Flag>
+                <t:FlagStatus>Flagged</t:FlagStatus>
+                <t:StartDate>2026-01-26T23:00:00Z</t:StartDate>
+                <t:DueDate>2026-01-26T23:00:00Z</t:DueDate>
+              </t:Flag>
             </t:Message>"#;
 
         let expected = Message {
@@ -1617,7 +1569,8 @@ mod tests {
 
     #[test]
     fn test_deserialize_empty_header() {
-        let content = r#"<InternetMessageHeader HeaderName="X-Is-Empty"/>"#;
+        let content = r#"
+            <InternetMessageHeader HeaderName="X-Is-Empty"/>"#;
         let expected = InternetMessageHeader {
             header_name: "X-Is-Empty".to_string(),
             value: None,

--- a/ews/src/types/copy_folder.rs
+++ b/ews/src/types/copy_folder.rs
@@ -22,7 +22,7 @@ pub struct CopyFolder {
 mod test {
     use crate::{
         copy_folder::{CopyFolder, CopyFolderResponse},
-        test_utils::{assert_deserialized_content, assert_serialized_content},
+        test_utils::{assert_deserialized_content, assert_serialized_content, minify_xml},
         BaseFolderId, CopyMoveFolderData, Folder, FolderId, FolderResponseMessage, Folders,
         ResponseClass,
     };
@@ -48,27 +48,40 @@ mod test {
             },
         };
 
-        let expected = r#"<CopyFolder xmlns="http://schemas.microsoft.com/exchange/services/2006/messages"><ToFolderId><t:DistinguishedFolderId Id="inbox"/></ToFolderId><FolderIds><t:FolderId Id="AS4A=" ChangeKey="fsVU4=="/><t:FolderId Id="AS4AU=" ChangeKey="fsVU4o=="/></FolderIds></CopyFolder>"#;
+        let expected = minify_xml(
+            r#"
+            <CopyFolder xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
+              <ToFolderId>
+                <t:DistinguishedFolderId Id="inbox"/>
+              </ToFolderId>
+              <FolderIds>
+                <t:FolderId Id="AS4A=" ChangeKey="fsVU4=="/>
+                <t:FolderId Id="AS4AU=" ChangeKey="fsVU4o=="/>
+              </FolderIds>
+            </CopyFolder>"#,
+        );
 
-        assert_serialized_content(&copy_folder, "CopyFolder", expected);
+        assert_serialized_content(&copy_folder, "CopyFolder", &expected);
     }
 
     #[test]
     fn test_deserialize_copy_folder_response() {
-        let content = r#"<CopyFolderResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
-                        xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types" 
-                        xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
-                        <m:ResponseMessages>
-                            <m:CopyFolderResponseMessage ResponseClass="Success">
-                            <m:ResponseCode>NoError</m:ResponseCode>
-                            <m:Folders>
-                                <t:Folder>
-                                <t:FolderId Id="AS4AUn=" ChangeKey="fsVU4o==" />
-                                </t:Folder>
-                            </m:Folders>
-                            </m:CopyFolderResponseMessage>
-                        </m:ResponseMessages>
-                        </CopyFolderResponse>"#;
+        let content = r#"
+            <CopyFolderResponse
+                xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
+                xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
+                xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
+              <m:ResponseMessages>
+                <m:CopyFolderResponseMessage ResponseClass="Success">
+                  <m:ResponseCode>NoError</m:ResponseCode>
+                  <m:Folders>
+                    <t:Folder>
+                      <t:FolderId Id="AS4AUn=" ChangeKey="fsVU4o==" />
+                    </t:Folder>
+                  </m:Folders>
+                </m:CopyFolderResponseMessage>
+              </m:ResponseMessages>
+            </CopyFolderResponse>"#;
 
         let response = CopyFolderResponse {
             response_messages: crate::ResponseMessages {

--- a/ews/src/types/copy_item.rs
+++ b/ews/src/types/copy_item.rs
@@ -22,7 +22,7 @@ pub struct CopyItem {
 mod test {
     use crate::{
         copy_item::{CopyItem, CopyItemResponse},
-        test_utils::{assert_deserialized_content, assert_serialized_content},
+        test_utils::{assert_deserialized_content, assert_serialized_content, minify_xml},
         BaseFolderId, BaseItemId, CopyMoveItemData, ItemId, ItemResponseMessage, Items, Message,
         RealItem, ResponseClass, ResponseMessages,
     };
@@ -43,27 +43,39 @@ mod test {
             },
         };
 
-        let expected = r#"<CopyItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages"><ToFolderId><t:DistinguishedFolderId Id="inbox"/></ToFolderId><ItemIds><t:ItemId Id="AS4AUnV="/></ItemIds></CopyItem>"#;
+        let expected = minify_xml(
+            r#"
+            <CopyItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
+              <ToFolderId>
+                <t:DistinguishedFolderId Id="inbox"/>
+              </ToFolderId>
+              <ItemIds>
+                <t:ItemId Id="AS4AUnV="/>
+              </ItemIds>
+            </CopyItem>"#,
+        );
 
-        assert_serialized_content(&request, "CopyItem", expected);
+        assert_serialized_content(&request, "CopyItem", &expected);
     }
 
     #[test]
     fn test_deserialize_copy_item_response() {
-        let content = r#"<CopyItemResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
-                      xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
-                      xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
-                        <m:ResponseMessages>
-                        <m:CopyItemResponseMessage ResponseClass="Success">
-                            <m:ResponseCode>NoError</m:ResponseCode>
-                            <m:Items>
-                                <t:Message>
-                                    <t:ItemId Id="AAMkAd" ChangeKey="FwAAABY" />
-                                </t:Message>
-                            </m:Items>
-                        </m:CopyItemResponseMessage>
-                        </m:ResponseMessages>
-                    </CopyItemResponse>"#;
+        let content = r#"
+            <CopyItemResponse
+                xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
+                xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
+                xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
+              <m:ResponseMessages>
+                <m:CopyItemResponseMessage ResponseClass="Success">
+                  <m:ResponseCode>NoError</m:ResponseCode>
+                  <m:Items>
+                    <t:Message>
+                      <t:ItemId Id="AAMkAd" ChangeKey="FwAAABY" />
+                    </t:Message>
+                  </m:Items>
+                </m:CopyItemResponseMessage>
+              </m:ResponseMessages>
+            </CopyItemResponse>"#;
 
         let expected = CopyItemResponse {
             response_messages: ResponseMessages {

--- a/ews/src/types/create_item.rs
+++ b/ews/src/types/create_item.rs
@@ -48,16 +48,18 @@ mod test {
 
     #[test]
     fn test_deserialize_create_item_response() {
-        let content = r#"<CreateItemResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
-                        xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
-                        xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
-                    <m:ResponseMessages>
-                        <m:CreateItemResponseMessage ResponseClass="Success">
-                        <m:ResponseCode>NoError</m:ResponseCode>
-                        <m:Items />
-                        </m:CreateItemResponseMessage>
-                    </m:ResponseMessages>
-                    </CreateItemResponse>"#;
+        let content = r#"
+            <CreateItemResponse
+                xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
+                xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
+                xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
+              <m:ResponseMessages>
+                <m:CreateItemResponseMessage ResponseClass="Success">
+                  <m:ResponseCode>NoError</m:ResponseCode>
+                  <m:Items />
+                </m:CreateItemResponseMessage>
+              </m:ResponseMessages>
+            </CreateItemResponse>"#;
 
         let expected = CreateItemResponse {
             response_messages: ResponseMessages {

--- a/ews/src/types/empty_folder.rs
+++ b/ews/src/types/empty_folder.rs
@@ -39,7 +39,7 @@ pub struct EmptyFolderResponseMessage {}
 mod test {
     use crate::{
         empty_folder::{EmptyFolder, EmptyFolderResponse, EmptyFolderResponseMessage},
-        test_utils::{assert_deserialized_content, assert_serialized_content},
+        test_utils::{assert_deserialized_content, assert_serialized_content, minify_xml},
         BaseFolderId, DeleteType, ResponseClass, ResponseMessages,
     };
 
@@ -54,21 +54,30 @@ mod test {
             }],
         };
 
-        let expected = r#"<EmptyFolder xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" DeleteType="HardDelete" DeleteSubFolders="true"><FolderIds><t:FolderId Id="AAMkADEzOTExYZRAAA=" ChangeKey="AQAAAAA3vA=="/></FolderIds></EmptyFolder>"#;
+        let expected = minify_xml(
+            r#"
+            <EmptyFolder xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" DeleteType="HardDelete" DeleteSubFolders="true">
+              <FolderIds>
+                <t:FolderId Id="AAMkADEzOTExYZRAAA=" ChangeKey="AQAAAAA3vA=="/>
+              </FolderIds>
+            </EmptyFolder>"#,
+        );
 
-        assert_serialized_content(&empty_folder, "EmptyFolder", expected);
+        assert_serialized_content(&empty_folder, "EmptyFolder", &expected);
     }
 
     #[test]
     fn test_deserialize_empty_folder_response() {
-        let content = r#"<m:EmptyFolderResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
-            xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
-                <m:ResponseMessages>
-                  <m:EmptyFolderResponseMessage ResponseClass="Success">
-                    <m:ResponseCode>NoError</m:ResponseCode>
-                  </m:EmptyFolderResponseMessage>
-                </m:ResponseMessages>
-              </m:EmptyFolderResponse>"#;
+        let content = r#"
+            <m:EmptyFolderResponse
+                xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
+                xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+              <m:ResponseMessages>
+                <m:EmptyFolderResponseMessage ResponseClass="Success">
+                  <m:ResponseCode>NoError</m:ResponseCode>
+                </m:EmptyFolderResponseMessage>
+              </m:ResponseMessages>
+            </m:EmptyFolderResponse>"#;
 
         let response = EmptyFolderResponse {
             response_messages: ResponseMessages {

--- a/ews/src/types/find_item.rs
+++ b/ews/src/types/find_item.rs
@@ -83,7 +83,7 @@ pub struct RootFolder {
 #[cfg(test)]
 mod tests {
     use crate::{
-        test_utils::{assert_deserialized_content, assert_serialized_content},
+        test_utils::{assert_deserialized_content, assert_serialized_content, minify_xml},
         BasePoint, BaseShape, Groups, ItemId, Items, Message, RealItem, ResponseClass,
         ResponseMessages,
     };
@@ -96,8 +96,7 @@ mod tests {
             traversal: Traversal::Shallow,
             item_shape: ItemShape {
                 base_shape: BaseShape::IdOnly,
-                include_mime_content: None,
-                additional_properties: None,
+                ..Default::default()
             },
             parent_folder_ids: vec![BaseFolderId::DistinguishedFolderId {
                 id: "deleteditems".to_string(),
@@ -110,19 +109,29 @@ mod tests {
             }),
         };
 
-        let expected = r#"<FindItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" Traversal="Shallow"><ItemShape><t:BaseShape>IdOnly</t:BaseShape></ItemShape><IndexedPageItemView MaxEntriesReturned="6" BasePoint="Beginning" Offset="0"/><ParentFolderIds><t:DistinguishedFolderId Id="deleteditems"/></ParentFolderIds></FindItem>"#;
+        let expected = minify_xml(
+            r#"
+            <FindItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" Traversal="Shallow">
+              <ItemShape>
+                <t:BaseShape>IdOnly</t:BaseShape>
+              </ItemShape>
+              <IndexedPageItemView MaxEntriesReturned="6" BasePoint="Beginning" Offset="0"/>
+              <ParentFolderIds>
+                <t:DistinguishedFolderId Id="deleteditems"/>
+              </ParentFolderIds>
+            </FindItem>"#,
+        );
 
-        assert_serialized_content(&find_item, "FindItem", expected);
+        assert_serialized_content(&find_item, "FindItem", &expected);
     }
 
     #[test]
     fn test_serialize_find_item_fractional_page_item_view() {
-        let finditem = FindItem {
+        let find_item = FindItem {
             traversal: Traversal::Shallow,
             item_shape: ItemShape {
                 base_shape: BaseShape::IdOnly,
-                include_mime_content: None,
-                additional_properties: None,
+                ..Default::default()
             },
             parent_folder_ids: vec![BaseFolderId::DistinguishedFolderId {
                 id: "inbox".to_string(),
@@ -135,18 +144,28 @@ mod tests {
             }),
         };
 
-        let expected = r#"<FindItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" Traversal="Shallow"><ItemShape><t:BaseShape>IdOnly</t:BaseShape></ItemShape><FractionalPageItemView MaxEntriesReturned="12" Numerator="2" Denominator="3"/><ParentFolderIds><t:DistinguishedFolderId Id="inbox"/></ParentFolderIds></FindItem>"#;
-        assert_serialized_content(&finditem, "FindItem", expected);
+        let expected = minify_xml(
+            r#"
+            <FindItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" Traversal="Shallow">
+              <ItemShape>
+                <t:BaseShape>IdOnly</t:BaseShape>
+              </ItemShape>
+              <FractionalPageItemView MaxEntriesReturned="12" Numerator="2" Denominator="3"/>
+              <ParentFolderIds>
+                <t:DistinguishedFolderId Id="inbox"/>
+              </ParentFolderIds>
+            </FindItem>"#,
+        );
+        assert_serialized_content(&find_item, "FindItem", &expected);
     }
 
     #[test]
     fn test_serialize_find_item_calendar_view() {
-        let finditem = FindItem {
+        let find_item = FindItem {
             traversal: Traversal::Shallow,
             item_shape: ItemShape {
                 base_shape: BaseShape::IdOnly,
-                include_mime_content: None,
-                additional_properties: None,
+                ..Default::default()
             },
             parent_folder_ids: vec![BaseFolderId::DistinguishedFolderId {
                 id: "calendar".to_string(),
@@ -159,19 +178,29 @@ mod tests {
             }),
         };
 
-        let expected = r#"<FindItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" Traversal="Shallow"><ItemShape><t:BaseShape>IdOnly</t:BaseShape></ItemShape><CalendarView MaxEntriesReturned="2" StartDate="2006-05-18T00:00:00-08:00" EndDate="2006-05-19T00:00:00-08:00"/><ParentFolderIds><t:DistinguishedFolderId Id="calendar"/></ParentFolderIds></FindItem>"#;
+        let expected = minify_xml(
+            r#"
+            <FindItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" Traversal="Shallow">
+              <ItemShape>
+                <t:BaseShape>IdOnly</t:BaseShape>
+              </ItemShape>
+              <CalendarView MaxEntriesReturned="2" StartDate="2006-05-18T00:00:00-08:00" EndDate="2006-05-19T00:00:00-08:00"/>
+              <ParentFolderIds>
+                <t:DistinguishedFolderId Id="calendar"/>
+              </ParentFolderIds>
+            </FindItem>"#,
+        );
 
-        assert_serialized_content(&finditem, "FindItem", expected);
+        assert_serialized_content(&find_item, "FindItem", &expected);
     }
 
     #[test]
     fn test_serialize_find_item_contacts_view() {
-        let finditem = FindItem {
+        let find_item = FindItem {
             traversal: Traversal::Shallow,
             item_shape: ItemShape {
                 base_shape: BaseShape::IdOnly,
-                include_mime_content: None,
-                additional_properties: None,
+                ..Default::default()
             },
             parent_folder_ids: vec![BaseFolderId::DistinguishedFolderId {
                 id: "contacts".to_string(),
@@ -184,17 +213,32 @@ mod tests {
             }),
         };
 
-        let expected = r#"<FindItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" Traversal="Shallow"><ItemShape><t:BaseShape>IdOnly</t:BaseShape></ItemShape><ContactsView MaxEntriesReturned="3" InitialName="Kelly Rollin"/><ParentFolderIds><t:DistinguishedFolderId Id="contacts"/></ParentFolderIds></FindItem>"#;
+        let expected = minify_xml(
+            r#"
+            <FindItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" Traversal="Shallow">
+              <ItemShape>
+                <t:BaseShape>IdOnly</t:BaseShape>
+              </ItemShape>
+              <ContactsView MaxEntriesReturned="3" InitialName="Kelly Rollin"/>
+              <ParentFolderIds>
+                <t:DistinguishedFolderId Id="contacts"/>
+              </ParentFolderIds>
+            </FindItem>"#,
+        );
 
-        assert_serialized_content(&finditem, "FindItem", expected);
+        assert_serialized_content(&find_item, "FindItem", &expected);
     }
 
     #[test]
     fn test_deserialize_root_folder() {
         let xml = r#"
-                    <m:RootFolder IndexedPagingOffset="1" NumeratorOffset="1" AbsoluteDenominator="1" IncludesLastItemInRange="true" TotalItemsInView="10">
-                        <Items/>
-                    </m:RootFolder>"#;
+            <m:RootFolder
+                IndexedPagingOffset="1"
+                NumeratorOffset="1"
+                AbsoluteDenominator="1"
+                IncludesLastItemInRange="true" TotalItemsInView="10">
+              <Items/>
+            </m:RootFolder>"#;
         let expected = RootFolder {
             indexed_paging_offset: Some(1),
             numerator_offset: Some(1),
@@ -211,23 +255,24 @@ mod tests {
     #[test]
     fn test_deserialize_find_item_response_message() {
         let content = r#"
-                    <FindItemResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
-                        xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
-                        xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
-                        <m:ResponseMessages>
-                            <m:FindItemResponseMessage ResponseClass="Success">
-                            <m:ResponseCode>NoError</m:ResponseCode>
-                            <m:RootFolder IncludesLastItemInRange="true" TotalItemsInView="10">
-                                <Items>
-                                    <t:Message>
-                                        <t:ItemId Id="AS4AUn=" ChangeKey="fsVU4==" />
-                                    </t:Message>
-                               </Items>
-                               <Groups/>
-                            </m:RootFolder>
-                            </m:FindItemResponseMessage>
-                        </m:ResponseMessages>
-                    </FindItemResponse>"#;
+            <FindItemResponse
+                xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
+                xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
+                xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
+              <m:ResponseMessages>
+                <m:FindItemResponseMessage ResponseClass="Success">
+                  <m:ResponseCode>NoError</m:ResponseCode>
+                  <m:RootFolder IncludesLastItemInRange="true" TotalItemsInView="10">
+                    <Items>
+                      <t:Message>
+                        <t:ItemId Id="AS4AUn=" ChangeKey="fsVU4==" />
+                      </t:Message>
+                    </Items>
+                    <Groups/>
+                  </m:RootFolder>
+                </m:FindItemResponseMessage>
+              </m:ResponseMessages>
+            </FindItemResponse>"#;
 
         let response = FindItemResponse {
             response_messages: ResponseMessages {

--- a/ews/src/types/mark_all_read.rs
+++ b/ews/src/types/mark_all_read.rs
@@ -33,7 +33,7 @@ mod test {
         mark_all_read::{
             MarkAllItemsAsRead, MarkAllItemsAsReadResponse, MarkAllItemsAsReadResponseMessage,
         },
-        test_utils::{assert_deserialized_content, assert_serialized_content},
+        test_utils::{assert_deserialized_content, assert_serialized_content, minify_xml},
         BaseFolderId, ResponseClass, ResponseMessages,
     };
 
@@ -48,20 +48,31 @@ mod test {
             }],
         };
 
-        let expected = r#"<MarkAllItemsAsRead xmlns="http://schemas.microsoft.com/exchange/services/2006/messages"><ReadFlag>true</ReadFlag><SuppressReadReceipts>true</SuppressReadReceipts><FolderIds><t:FolderId Id="AAMkADEzOTExYZRAAA=" ChangeKey="AQAAAAA3vA=="/></FolderIds></MarkAllItemsAsRead>"#;
+        let expected = minify_xml(
+            r#"
+            <MarkAllItemsAsRead xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
+              <ReadFlag>true</ReadFlag>
+              <SuppressReadReceipts>true</SuppressReadReceipts>
+              <FolderIds>
+                <t:FolderId Id="AAMkADEzOTExYZRAAA=" ChangeKey="AQAAAAA3vA=="/>
+              </FolderIds>
+            </MarkAllItemsAsRead>"#,
+        );
 
-        assert_serialized_content(&mark_all_items_as_read, "MarkAllItemsAsRead", expected);
+        assert_serialized_content(&mark_all_items_as_read, "MarkAllItemsAsRead", &expected);
     }
 
     #[test]
     fn test_deserialize_mark_all_items_as_read_response() {
-        let content = r#"<m:MarkAllItemsAsReadResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
-            xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
-                <m:ResponseMessages>
-                    <m:MarkAllItemsAsReadResponseMessage ResponseClass="Success">
-                        <m:ResponseCode>NoError</m:ResponseCode>
-                    </m:MarkAllItemsAsReadResponseMessage>
-                </m:ResponseMessages>
+        let content = r#"
+            <m:MarkAllItemsAsReadResponse
+                xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
+                xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+              <m:ResponseMessages>
+                <m:MarkAllItemsAsReadResponseMessage ResponseClass="Success">
+                  <m:ResponseCode>NoError</m:ResponseCode>
+                </m:MarkAllItemsAsReadResponseMessage>
+              </m:ResponseMessages>
             </m:MarkAllItemsAsReadResponse>"#;
 
         let response = MarkAllItemsAsReadResponse {

--- a/ews/src/types/mark_as_junk.rs
+++ b/ews/src/types/mark_as_junk.rs
@@ -32,11 +32,9 @@ pub struct MarkAsJunkResponseMessage {
 
 #[cfg(test)]
 mod test {
-    use std::vec;
-
     use crate::{
         mark_as_junk::{MarkAsJunk, MarkAsJunkResponse, MarkAsJunkResponseMessage},
-        test_utils::{assert_deserialized_content, assert_serialized_content},
+        test_utils::{assert_deserialized_content, assert_serialized_content, minify_xml},
         BaseItemId, ItemId, ResponseClass, ResponseMessages,
     };
 
@@ -51,21 +49,30 @@ mod test {
             }],
         };
 
-        let expected = r#"<MarkAsJunk xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" IsJunk="true" MoveItem="true"><ItemIds><t:ItemId Id="AAMkAD=" ChangeKey="CQAAABYA"/></ItemIds></MarkAsJunk>"#;
+        let expected = minify_xml(
+            r#"
+            <MarkAsJunk xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" IsJunk="true" MoveItem="true">
+              <ItemIds>
+                <t:ItemId Id="AAMkAD=" ChangeKey="CQAAABYA"/>
+              </ItemIds>
+            </MarkAsJunk>"#,
+        );
 
-        assert_serialized_content(&mark_as_junk, "MarkAsJunk", expected);
+        assert_serialized_content(&mark_as_junk, "MarkAsJunk", &expected);
     }
 
     #[test]
     fn test_deserialize_mark_as_junk_response() {
-        let content = r#"<m:MarkAsJunkResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
-            xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
-            <m:ResponseMessages>
+        let content = r#"
+            <m:MarkAsJunkResponse
+                xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
+                xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+              <m:ResponseMessages>
                 <m:MarkAsJunkResponseMessage ResponseClass="Success">
-                    <m:ResponseCode>NoError</m:ResponseCode>
-                    <m:MovedItemId Id="AAMkAD=" ChangeKey="CQAAABYu" />
+                  <m:ResponseCode>NoError</m:ResponseCode>
+                  <m:MovedItemId Id="AAMkAD=" ChangeKey="CQAAABYu" />
                 </m:MarkAsJunkResponseMessage>
-            </m:ResponseMessages>
+              </m:ResponseMessages>
             </m:MarkAsJunkResponse>"#;
 
         let response = MarkAsJunkResponse {

--- a/ews/src/types/move_folder.rs
+++ b/ews/src/types/move_folder.rs
@@ -22,7 +22,7 @@ pub struct MoveFolder {
 mod test {
     use crate::{
         move_folder::{MoveFolder, MoveFolderResponse},
-        test_utils::{assert_deserialized_content, assert_serialized_content},
+        test_utils::{assert_deserialized_content, assert_serialized_content, minify_xml},
         BaseFolderId, CopyMoveFolderData, Folder, FolderId, FolderResponseMessage, Folders,
         ResponseClass, ResponseMessages,
     };
@@ -42,27 +42,39 @@ mod test {
             },
         };
 
-        let expected = r#"<MoveFolder xmlns="http://schemas.microsoft.com/exchange/services/2006/messages"><ToFolderId><t:DistinguishedFolderId Id="junkemail"/></ToFolderId><FolderIds><t:FolderId Id="AScAc"/></FolderIds></MoveFolder>"#;
+        let expected = minify_xml(
+            r#"
+            <MoveFolder xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
+              <ToFolderId>
+                <t:DistinguishedFolderId Id="junkemail"/>
+              </ToFolderId>
+              <FolderIds>
+                <t:FolderId Id="AScAc"/>
+              </FolderIds>
+            </MoveFolder>"#,
+        );
 
-        assert_serialized_content(&move_folder, "MoveFolder", expected);
+        assert_serialized_content(&move_folder, "MoveFolder", &expected);
     }
 
     #[test]
     fn test_deserialize_move_folder_response() {
-        let content = r#"<MoveFolderResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
-                    xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
-                    xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
-                    <m:ResponseMessages>
-                        <m:MoveFolderResponseMessage ResponseClass="Success">
-                        <m:ResponseCode>NoError</m:ResponseCode>
-                        <m:Folders>
-                            <t:Folder>
-                            <t:FolderId Id="AAAlAFV" ChangeKey="AQAAAB" />
-                            </t:Folder>
-                        </m:Folders>
-                        </m:MoveFolderResponseMessage>
-                    </m:ResponseMessages>
-                    </MoveFolderResponse>"#;
+        let content = r#"
+            <MoveFolderResponse
+                xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
+                xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
+                xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
+              <m:ResponseMessages>
+                <m:MoveFolderResponseMessage ResponseClass="Success">
+                  <m:ResponseCode>NoError</m:ResponseCode>
+                  <m:Folders>
+                    <t:Folder>
+                      <t:FolderId Id="AAAlAFV" ChangeKey="AQAAAB" />
+                    </t:Folder>
+                  </m:Folders>
+                </m:MoveFolderResponseMessage>
+              </m:ResponseMessages>
+            </MoveFolderResponse>"#;
 
         let response = MoveFolderResponse {
             response_messages: ResponseMessages {

--- a/ews/src/types/move_item.rs
+++ b/ews/src/types/move_item.rs
@@ -23,7 +23,7 @@ pub struct MoveItem {
 #[cfg(test)]
 mod test {
     use crate::{
-        test_utils::{assert_deserialized_content, assert_serialized_content},
+        test_utils::{assert_deserialized_content, assert_serialized_content, minify_xml},
         types::common::ItemResponseMessage,
         BaseFolderId, BaseItemId, CopyMoveItemData, ItemId, Items, Message, RealItem,
         ResponseClass, ResponseMessages,
@@ -47,26 +47,38 @@ mod test {
             },
         };
 
-        let expected = r#"<MoveItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages"><ToFolderId><t:DistinguishedFolderId Id="drafts"/></ToFolderId><ItemIds><t:ItemId Id="AAAtAEF/swbAAA=" ChangeKey="EwAAABYA/s4b"/></ItemIds></MoveItem>"#;
+        let expected = minify_xml(
+            r#"
+            <MoveItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
+              <ToFolderId>
+                <t:DistinguishedFolderId Id="drafts"/>
+              </ToFolderId>
+              <ItemIds>
+                <t:ItemId Id="AAAtAEF/swbAAA=" ChangeKey="EwAAABYA/s4b"/>
+              </ItemIds>
+            </MoveItem>"#,
+        );
 
-        assert_serialized_content(&move_item, "MoveItem", expected);
+        assert_serialized_content(&move_item, "MoveItem", &expected);
     }
 
     #[test]
     fn test_deserialize_move_item_response() {
-        let content = r#"<MoveItemResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
-                    xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
-                    xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
-                    <m:ResponseMessages>
-                    <m:MoveItemResponseMessage ResponseClass="Success">
-                    <m:ResponseCode>NoError</m:ResponseCode>
-                    <m:Items>
-                        <t:Message>
-                        <t:ItemId Id="AAMkAd" ChangeKey="FwAAABY" />
-                        </t:Message>
-                    </m:Items>
-                    </m:MoveItemResponseMessage>
-                </m:ResponseMessages>
+        let content = r#"
+            <MoveItemResponse
+                xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
+                xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
+                xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
+              <m:ResponseMessages>
+                <m:MoveItemResponseMessage ResponseClass="Success">
+                  <m:ResponseCode>NoError</m:ResponseCode>
+                  <m:Items>
+                    <t:Message>
+                      <t:ItemId Id="AAMkAd" ChangeKey="FwAAABY" />
+                    </t:Message>
+                  </m:Items>
+                </m:MoveItemResponseMessage>
+              </m:ResponseMessages>
             </MoveItemResponse>"#;
 
         let response = MoveItemResponse {

--- a/ews/src/types/soap.rs
+++ b/ews/src/types/soap.rs
@@ -207,6 +207,37 @@ mod tests {
 
     use super::Envelope;
 
+    fn assert_deserialized_envelope_body<T>(content: &str, expected: T)
+    where
+        T: OperationResponse + Eq + std::fmt::Debug,
+    {
+        let envelope: Envelope<T> = Envelope::from_xml_document(content.as_bytes())
+            .expect("deserialization should succeed");
+        assert_eq!(envelope.body, expected);
+    }
+
+    fn folder_response_message() -> GetFolderResponseMessage {
+        GetFolderResponseMessage {
+            folders: Folders {
+                inner: vec![Folder::Folder {
+                    folder_id: Some(FolderId {
+                        id: "AQMkADRiZGNhMWIxLWIwOGMtNDQAZjktODk3OS0zZWIxODJjNmI4NWYALgAAA8ZmIFRjoG9PpiagjztHaIcBAFSUeaisgPtKo3c6hV+VzpcAAAIBCAAAAA==".to_owned(),
+                        change_key: Some(
+                            "AQAAABYAAABUlHmorID7SqN3OoVflc6XAAAAAACW".to_owned(),
+                        ),
+                    }),
+                    parent_folder_id: None,
+                    folder_class: None,
+                    display_name: None,
+                    total_count: None,
+                    child_folder_count: None,
+                    extended_property: None,
+                    unread_count: None,
+                }],
+            },
+        }
+    }
+
     #[test]
     fn deserialize_envelope_with_content() {
         #[derive(Clone, Debug, Deserialize)]
@@ -231,14 +262,23 @@ mod tests {
 
         // This XML is contrived, with a custom structure defined in order to
         // test the generic behavior of the interface.
-        let xml = r#"<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header></s:Header><s:Body><foo:Foo><text>testing content</text><other_field/></foo:Foo></s:Body></s:Envelope>"#;
+        let xml = r#"
+            <?xml version="1.0" encoding="utf-8"?>
+            <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+              <s:Header></s:Header>
+              <s:Body>
+                <foo:Foo>
+                  <text>testing content</text>
+                  <other_field/>
+                </foo:Foo>
+              </s:Body>
+            </s:Envelope>"#;
 
         let actual: Envelope<SomeStruct> =
             Envelope::from_xml_document(xml.as_bytes()).expect("deserialization should succeed");
 
         assert_eq!(
-            actual.body.text,
-            String::from("testing content"),
+            actual.body.text, "testing content",
             "text field should match original document"
         );
     }
@@ -261,8 +301,27 @@ mod tests {
         // to the MessageXml enum. Right now, it's testing an "unknown" tagged
         // element variant with multiple elements.
 
-        // This XML is drawn from testing data for `evolution-ews`.
-        let xml = r#"<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Body><s:Fault><faultcode xmlns:a="http://schemas.microsoft.com/exchange/services/2006/types">a:ErrorSchemaValidation</faultcode><faultstring xml:lang="en-US">The request failed schema validation: The 'Id' attribute is invalid - The value 'invalidparentid' is invalid according to its datatype 'http://schemas.microsoft.com/exchange/services/2006/types:DistinguishedFolderIdNameType' - The Enumeration constraint failed.</faultstring><detail><e:ResponseCode xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">ErrorSchemaValidation</e:ResponseCode><e:Message xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">The request failed schema validation.</e:Message><t:MessageXml xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><t:LineNumber>2</t:LineNumber><t:LinePosition>630</t:LinePosition><t:Violation>The 'Id' attribute is invalid - The value 'invalidparentid' is invalid according to its datatype 'http://schemas.microsoft.com/exchange/services/2006/types:DistinguishedFolderIdNameType' - The Enumeration constraint failed.</t:Violation></t:MessageXml></detail></s:Fault></s:Body></s:Envelope>"#;
+        // This XML is drawn from testing data for `evolution-ews`, with
+        // whitespace added for readability.
+        let xml = r#"
+            <?xml version="1.0" encoding="utf-8"?>
+            <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+              <s:Body>
+                <s:Fault>
+                  <faultcode xmlns:a="http://schemas.microsoft.com/exchange/services/2006/types">a:ErrorSchemaValidation</faultcode>
+                  <faultstring xml:lang="en-US">The request failed schema validation: The 'Id' attribute is invalid - The value 'invalidparentid' is invalid according to its datatype 'http://schemas.microsoft.com/exchange/services/2006/types:DistinguishedFolderIdNameType' - The Enumeration constraint failed.</faultstring>
+                  <detail>
+                    <e:ResponseCode xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">ErrorSchemaValidation</e:ResponseCode>
+                    <e:Message xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">The request failed schema validation.</e:Message>
+                    <t:MessageXml xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+                      <t:LineNumber>2</t:LineNumber>
+                      <t:LinePosition>630</t:LinePosition>
+                      <t:Violation>The 'Id' attribute is invalid - The value 'invalidparentid' is invalid according to its datatype 'http://schemas.microsoft.com/exchange/services/2006/types:DistinguishedFolderIdNameType' - The Enumeration constraint failed.</t:Violation>
+                    </t:MessageXml>
+                  </detail>
+                </s:Fault>
+              </s:Body>
+            </s:Envelope>"#;
 
         let err = <Envelope<FooResponse>>::from_xml_document(xml.as_bytes())
             .expect_err("should return error when body contains fault");
@@ -327,24 +386,25 @@ mod tests {
         // testing an "unknown" Value variant with multiple Values.
 
         // This XML is based on https://github.com/OfficeDev/ews-managed-api/issues/293#issuecomment-1506483638
-        let xml = r#"<?xml version="1.0" encoding="utf-8"?>
-<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
-  <s:Body>
-    <s:Fault>
-      <faultcode xmlns:a="http://schemas.microsoft.com/exchange/services/2006/types">a:ErrorExceededConnectionCount</faultcode>
-      <faultstring xml:lang="en-US">You have exceeded the available concurrent connections for your account.  Try again once your other requests have completed.</faultstring>
-      <detail>
-        <e:ResponseCode xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">ErrorExceededConnectionCount</e:ResponseCode>
-        <e:Message xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">You have exceeded the available concurrent connections for your account.  Try again once your other requests have completed.</e:Message>
-        <t:MessageXml xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
-          <t:Value Name="Policy">MaxConcurrency</t:Value>
-          <t:Value Name="MaxConcurrencyLimit">27</t:Value>
-          <t:Value Name="ErrorMessage">This operation exceeds the throttling budget for policy part 'MaxConcurrency', policy value '27',  Budget type: 'Ews'.  Suggested backoff time 0 ms.</t:Value>
-        </t:MessageXml>
-      </detail>
-    </s:Fault>
-  </s:Body>
-</s:Envelope>"#;
+        let xml = r#"
+            <?xml version="1.0" encoding="utf-8"?>
+            <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+              <s:Body>
+                <s:Fault>
+                  <faultcode xmlns:a="http://schemas.microsoft.com/exchange/services/2006/types">a:ErrorExceededConnectionCount</faultcode>
+                  <faultstring xml:lang="en-US">You have exceeded the available concurrent connections for your account.  Try again once your other requests have completed.</faultstring>
+                  <detail>
+                    <e:ResponseCode xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">ErrorExceededConnectionCount</e:ResponseCode>
+                    <e:Message xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">You have exceeded the available concurrent connections for your account.  Try again once your other requests have completed.</e:Message>
+                    <t:MessageXml xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+                      <t:Value Name="Policy">MaxConcurrency</t:Value>
+                      <t:Value Name="MaxConcurrencyLimit">27</t:Value>
+                      <t:Value Name="ErrorMessage">This operation exceeds the throttling budget for policy part 'MaxConcurrency', policy value '27',  Budget type: 'Ews'.  Suggested backoff time 0 ms.</t:Value>
+                    </t:MessageXml>
+                  </detail>
+                </s:Fault>
+              </s:Body>
+            </s:Envelope>"#;
 
         let err = <Envelope<FooResponse>>::from_xml_document(xml.as_bytes())
             .expect_err("should return error when body contains fault");
@@ -405,7 +465,23 @@ mod tests {
         // This XML is contrived based on what's known of the shape of
         // `ErrorServerBusy` responses. It should be replaced when we have
         // real-life examples.
-        let xml = r#"<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Body><s:Fault><faultcode xmlns:a="http://schemas.microsoft.com/exchange/services/2006/types">a:ErrorServerBusy</faultcode><faultstring xml:lang="en-US">I made this up because I don't have real testing data. 🙃</faultstring><detail><e:ResponseCode xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">ErrorServerBusy</e:ResponseCode><e:Message xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">Who really knows?</e:Message><t:MessageXml xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><t:Value Name="BackOffMilliseconds">25</t:Value></t:MessageXml></detail></s:Fault></s:Body></s:Envelope>"#;
+        let xml = r#"
+            <?xml version="1.0" encoding="utf-8"?>
+            <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+              <s:Body>
+                <s:Fault>
+                  <faultcode xmlns:a="http://schemas.microsoft.com/exchange/services/2006/types">a:ErrorServerBusy</faultcode>
+                  <faultstring xml:lang="en-US">I made this up because I don't have real testing data. 🙃</faultstring>
+                  <detail>
+                    <e:ResponseCode xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">ErrorServerBusy</e:ResponseCode>
+                    <e:Message xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">Who really knows?</e:Message>
+                    <t:MessageXml xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+                      <t:Value Name="BackOffMilliseconds">25</t:Value>
+                    </t:MessageXml>
+                  </detail>
+                </s:Fault>
+              </s:Body>
+            </s:Envelope>"#;
 
         let err = <Envelope<FooResponse>>::from_xml_document(xml.as_bytes())
             .expect_err("should return error when body contains fault");
@@ -447,50 +523,55 @@ mod tests {
     fn deserialize_envelope_with_server_busy_error() {
         // Similar to the above, except instead of a fault, the server
         // busy message is sent in the body of a response as an error.
-        let xml = r#"<?xml version="1.0" encoding="utf-8"?>
-                     <s:Envelope
-                         xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
-                         <s:Header>
-                             <h:ServerVersionInfo MajorVersion="15" MinorVersion="20" MajorBuildNumber="8769" MinorBuildNumber="35" Version="V2018_01_08"
-                                                  xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types"
-                                                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-                                                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
-                         </s:Header>
-                         <s:Body>
-                             <m:SyncFolderItemsResponse
-                                 xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
-                                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                                 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-                                 xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
-                                 <m:ResponseMessages>
-                                     <m:SyncFolderItemsResponseMessage ResponseClass="Error">
-                                         <m:MessageText>The server cannot service this request right now. Try again later., This operation exceeds the throttling budget for policy part 'ConcurrentSyncCalls', policy value '5',  Budget type: 'Ews'.  Suggested backoff time 5000 ms.</m:MessageText>
-                                         <m:ResponseCode>ErrorServerBusy</m:ResponseCode>
-                                         <m:DescriptiveLinkKey>0</m:DescriptiveLinkKey>
-                                         <m:MessageXml>
-                                             <t:Value Name="BackOffMilliseconds">5000</t:Value>
-                                         </m:MessageXml>
-                                         <m:SyncState/>
-                                         <m:IncludesLastItemInRange>true</m:IncludesLastItemInRange>
-                                     </m:SyncFolderItemsResponseMessage>
-                                 </m:ResponseMessages>
-                             </m:SyncFolderItemsResponse>
-                         </s:Body>
-                     </s:Envelope>"#;
+        let xml = r#"
+            <?xml version="1.0" encoding="utf-8"?>
+            <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+              <s:Header>
+                <h:ServerVersionInfo
+                    MajorVersion="15"
+                    MinorVersion="20"
+                    MajorBuildNumber="8769"
+                    MinorBuildNumber="35"
+                    Version="V2018_01_08"
+                    xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types"
+                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+              </s:Header>
+              <s:Body>
+                <m:SyncFolderItemsResponse
+                    xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                    xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+                  <m:ResponseMessages>
+                    <m:SyncFolderItemsResponseMessage ResponseClass="Error">
+                      <m:MessageText>The server cannot service this request right now. Try again later., This operation exceeds the throttling budget for policy part 'ConcurrentSyncCalls', policy value '5',  Budget type: 'Ews'.  Suggested backoff time 5000 ms.</m:MessageText>
+                      <m:ResponseCode>ErrorServerBusy</m:ResponseCode>
+                      <m:DescriptiveLinkKey>0</m:DescriptiveLinkKey>
+                      <m:MessageXml>
+                        <t:Value Name="BackOffMilliseconds">5000</t:Value>
+                      </m:MessageXml>
+                      <m:SyncState/>
+                      <m:IncludesLastItemInRange>true</m:IncludesLastItemInRange>
+                    </m:SyncFolderItemsResponseMessage>
+                  </m:ResponseMessages>
+                </m:SyncFolderItemsResponse>
+              </s:Body>
+            </s:Envelope>"#;
 
-        let expected_resp = SyncFolderItemsResponse {
-            response_messages: ResponseMessages { response_messages: vec![
-                ResponseClass::Error(ResponseError {
+        let expected = SyncFolderItemsResponse {
+            response_messages: ResponseMessages {
+                response_messages: vec![ResponseClass::Error(ResponseError {
                     message_text: "The server cannot service this request right now. Try again later., This operation exceeds the throttling budget for policy part 'ConcurrentSyncCalls', policy value '5',  Budget type: 'Ews'.  Suggested backoff time 5000 ms.".to_string(),
                     response_code: ResponseCode::ErrorServerBusy,
-                    message_xml: Some(MessageXml::ServerBusy(ServerBusy { back_off_milliseconds: 5000 }))
-                })
-            ] }
+                    message_xml: Some(MessageXml::ServerBusy(ServerBusy {
+                        back_off_milliseconds: 5000,
+                    })),
+                })],
+            },
         };
 
-        let envelope: Envelope<SyncFolderItemsResponse> =
-            Envelope::from_xml_document(xml.as_bytes()).expect("deserialization should succeed");
-        assert_eq!(envelope.body, expected_resp);
+        assert_deserialized_envelope_body(xml, expected);
     }
 
     /// Test that deserializing succeeds when the SOAP body includes attributes.
@@ -500,66 +581,53 @@ mod tests {
     fn deserialize_envelope_with_attributes_in_body() {
         // This XML comes from a real life request against one of our test
         // accounts, using an Exchange Server 2016 instance.
-        let xml = r#"<?xml version="1.0" encoding="utf-8"?>
-                     <s:Envelope
-                         xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
-                         <s:Header>
-                             <h:ServerVersionInfo MajorVersion="15" MinorVersion="1" MajorBuildNumber="2507" MinorBuildNumber="57" Version="V2017_07_11"
-                                 xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types"
-                                 xmlns="http://schemas.microsoft.com/exchange/services/2006/types"
-                                 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-                                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
-                             </s:Header>
-                             <s:Body
-                                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                                 xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-                                 <m:GetFolderResponse
-                                     xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
-                                     xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
-                                     <m:ResponseMessages>
-                                         <m:GetFolderResponseMessage ResponseClass="Success">
-                                             <m:ResponseCode>NoError</m:ResponseCode>
-                                             <m:Folders>
-                                                 <t:Folder>
-                                                     <t:FolderId Id="AQMkADRiZGNhMWIxLWIwOGMtNDQAZjktODk3OS0zZWIxODJjNmI4NWYALgAAA8ZmIFRjoG9PpiagjztHaIcBAFSUeaisgPtKo3c6hV+VzpcAAAIBCAAAAA==" ChangeKey="AQAAABYAAABUlHmorID7SqN3OoVflc6XAAAAAACW"/>
-                                                 </t:Folder>
-                                             </m:Folders>
-                                         </m:GetFolderResponseMessage>
-                                     </m:ResponseMessages>
-                                 </m:GetFolderResponse>
-                             </s:Body>
-                         </s:Envelope>"#;
+        let xml = r#"
+            <?xml version="1.0" encoding="utf-8"?>
+            <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+              <s:Header>
+                <h:ServerVersionInfo
+                    MajorVersion="15"
+                    MinorVersion="1"
+                    MajorBuildNumber="2507"
+                    MinorBuildNumber="57"
+                    Version="V2017_07_11"
+                    xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types"
+                    xmlns="http://schemas.microsoft.com/exchange/services/2006/types"
+                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+              </s:Header>
+              <s:Body
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                <m:GetFolderResponse
+                    xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
+                    xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+                  <m:ResponseMessages>
+                    <m:GetFolderResponseMessage ResponseClass="Success">
+                      <m:ResponseCode>NoError</m:ResponseCode>
+                      <m:Folders>
+                        <t:Folder>
+                          <t:FolderId
+                              Id="AQMkADRiZGNhMWIxLWIwOGMtNDQAZjktODk3OS0zZWIxODJjNmI4NWYALgAAA8ZmIFRjoG9PpiagjztHaIcBAFSUeaisgPtKo3c6hV+VzpcAAAIBCAAAAA=="
+                              ChangeKey="AQAAABYAAABUlHmorID7SqN3OoVflc6XAAAAAACW"/>
+                        </t:Folder>
+                      </m:Folders>
+                    </m:GetFolderResponseMessage>
+                  </m:ResponseMessages>
+                </m:GetFolderResponse>
+              </s:Body>
+            </s:Envelope>"#;
 
-        let expected_resp = GetFolderResponse {
+        let expected = GetFolderResponse {
             response_messages: ResponseMessages {
-                response_messages: vec![ResponseClass::Success(GetFolderResponseMessage {
-                    folders: Folders { inner: vec![
-                        Folder::Folder {
-                            folder_id: Some(FolderId {
-                                id: "AQMkADRiZGNhMWIxLWIwOGMtNDQAZjktODk3OS0zZWIxODJjNmI4NWYALgAAA8ZmIFRjoG9PpiagjztHaIcBAFSUeaisgPtKo3c6hV+VzpcAAAIBCAAAAA==".to_owned(),
-                                change_key: Some("AQAAABYAAABUlHmorID7SqN3OoVflc6XAAAAAACW".to_owned())
-                            }),
-                            parent_folder_id: None,
-                            folder_class: None,
-                            display_name: None,
-                            total_count: None,
-                            child_folder_count: None,
-                            extended_property: None,
-                            unread_count: None
-                        }
-                    ]},
-                })],
+                response_messages: vec![ResponseClass::Success(folder_response_message())],
             },
         };
 
         // Check that the XML is successfully deserialized in the first place,
         // with no error caused by the presence of attributes in the `s:Body`
         // element.
-        let envelope: Envelope<GetFolderResponse> =
-            Envelope::from_xml_document(xml.as_bytes()).expect("deserialization should succeed");
-
-        // Check that the parsed body is in line with what we expect.
-        assert_eq!(envelope.body, expected_resp);
+        assert_deserialized_envelope_body(xml, expected);
     }
 
     #[test]
@@ -569,66 +637,53 @@ mod tests {
         // deserialize_envelope_with_attributes_in_body above). It's also currently subject to the
         // problems with our Warning variant of ResponseClass (namely, that it can't convey the
         // error fields).
-        let xml = r#"<?xml version="1.0" encoding="utf-8"?>
-                     <s:Envelope
-                         xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
-                         <s:Header>
-                             <h:ServerVersionInfo MajorVersion="15" MinorVersion="1" MajorBuildNumber="2507" MinorBuildNumber="57" Version="V2017_07_11"
-                                 xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types"
-                                 xmlns="http://schemas.microsoft.com/exchange/services/2006/types"
-                                 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-                                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
-                             </s:Header>
-                             <s:Body
-                                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                                 xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-                                 <m:GetFolderResponse
-                                     xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
-                                     xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
-                                     <m:ResponseMessages>
-                                         <m:GetFolderResponseMessage ResponseClass="Warning">
-                                           <m:MessageText>Multiple results were found.</m:MessageText>
-                                           <m:ResponseCode>ErrorNameResolutionMultipleResults</m:ResponseCode>
-                                           <m:DescriptiveLinkKey>0</m:DescriptiveLinkKey>
-                                           <m:Folders>
-                                               <t:Folder>
-                                                   <t:FolderId Id="AQMkADRiZGNhMWIxLWIwOGMtNDQAZjktODk3OS0zZWIxODJjNmI4NWYALgAAA8ZmIFRjoG9PpiagjztHaIcBAFSUeaisgPtKo3c6hV+VzpcAAAIBCAAAAA==" ChangeKey="AQAAABYAAABUlHmorID7SqN3OoVflc6XAAAAAACW"/>
-                                               </t:Folder>
-                                           </m:Folders>
-                                        </m:GetFolderResponseMessage>
-                                     </m:ResponseMessages>
-                                 </m:GetFolderResponse>
-                             </s:Body>
-                         </s:Envelope>"#;
+        let xml = r#"
+            <?xml version="1.0" encoding="utf-8"?>
+            <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+              <s:Header>
+                <h:ServerVersionInfo
+                    MajorVersion="15"
+                    MinorVersion="1"
+                    MajorBuildNumber="2507"
+                    MinorBuildNumber="57"
+                    Version="V2017_07_11"
+                    xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types"
+                    xmlns="http://schemas.microsoft.com/exchange/services/2006/types"
+                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+              </s:Header>
+              <s:Body
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                <m:GetFolderResponse
+                    xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
+                    xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+                  <m:ResponseMessages>
+                    <m:GetFolderResponseMessage ResponseClass="Warning">
+                      <m:MessageText>Multiple results were found.</m:MessageText>
+                      <m:ResponseCode>ErrorNameResolutionMultipleResults</m:ResponseCode>
+                      <m:DescriptiveLinkKey>0</m:DescriptiveLinkKey>
+                      <m:Folders>
+                        <t:Folder>
+                          <t:FolderId
+                              Id="AQMkADRiZGNhMWIxLWIwOGMtNDQAZjktODk3OS0zZWIxODJjNmI4NWYALgAAA8ZmIFRjoG9PpiagjztHaIcBAFSUeaisgPtKo3c6hV+VzpcAAAIBCAAAAA=="
+                              ChangeKey="AQAAABYAAABUlHmorID7SqN3OoVflc6XAAAAAACW"/>
+                        </t:Folder>
+                      </m:Folders>
+                    </m:GetFolderResponseMessage>
+                  </m:ResponseMessages>
+                </m:GetFolderResponse>
+              </s:Body>
+            </s:Envelope>"#;
 
-        let expected_resp = GetFolderResponse {
+        let expected = GetFolderResponse {
             response_messages: ResponseMessages {
-                response_messages: vec![ResponseClass::Warning(GetFolderResponseMessage {
-                    folders: Folders { inner: vec![
-                        Folder::Folder {
-                            folder_id: Some(FolderId {
-                                id: "AQMkADRiZGNhMWIxLWIwOGMtNDQAZjktODk3OS0zZWIxODJjNmI4NWYALgAAA8ZmIFRjoG9PpiagjztHaIcBAFSUeaisgPtKo3c6hV+VzpcAAAIBCAAAAA==".to_owned(),
-                                change_key: Some("AQAAABYAAABUlHmorID7SqN3OoVflc6XAAAAAACW".to_owned())
-                            }),
-                            parent_folder_id: None,
-                            folder_class: None,
-                            display_name: None,
-                            total_count: None,
-                            child_folder_count: None,
-                            extended_property: None,
-                            unread_count: None
-                        }
-                    ]},
-                })],
+                response_messages: vec![ResponseClass::Warning(folder_response_message())],
             },
         };
 
         // Check that the XML is successfully deserialized in the first place,
         // with no error caused by use of the Warning variant.
-        let envelope: Envelope<GetFolderResponse> =
-            Envelope::from_xml_document(xml.as_bytes()).expect("deserialization should succeed");
-
-        // Check that the parsed body is in line with what we expect.
-        assert_eq!(envelope.body, expected_resp);
+        assert_deserialized_envelope_body(xml, expected);
     }
 }

--- a/ews/src/types/update_folder.rs
+++ b/ews/src/types/update_folder.rs
@@ -80,8 +80,7 @@ pub struct UpdateFolderResponseMessage {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::assert_deserialized_content;
-    use crate::test_utils::assert_serialized_content;
+    use crate::test_utils::{assert_deserialized_content, assert_serialized_content, minify_xml};
     use crate::{BaseFolderId, FolderId, ResponseClass, ResponseMessages};
 
     #[test]
@@ -112,26 +111,45 @@ mod tests {
             },
         };
 
-        let expected = r#"<UpdateFolder xmlns="http://schemas.microsoft.com/exchange/services/2006/messages"><FolderChanges><t:FolderChange><t:FolderId Id="AScA" ChangeKey="GO3u/"/><t:Updates><t:SetFolderField><t:FieldURI FieldURI="folder:DisplayName"/><t:Folder><t:DisplayName>NewFolderName</t:DisplayName></t:Folder></t:SetFolderField></t:Updates></t:FolderChange></FolderChanges></UpdateFolder>"#;
+        let expected = minify_xml(
+            r#"
+            <UpdateFolder xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
+              <FolderChanges>
+                <t:FolderChange>
+                  <t:FolderId Id="AScA" ChangeKey="GO3u/"/>
+                  <t:Updates>
+                    <t:SetFolderField>
+                      <t:FieldURI FieldURI="folder:DisplayName"/>
+                      <t:Folder>
+                        <t:DisplayName>NewFolderName</t:DisplayName>
+                      </t:Folder>
+                    </t:SetFolderField>
+                  </t:Updates>
+                </t:FolderChange>
+              </FolderChanges>
+            </UpdateFolder>"#,
+        );
 
-        assert_serialized_content(&update_folder, "UpdateFolder", expected);
+        assert_serialized_content(&update_folder, "UpdateFolder", &expected);
     }
 
     #[test]
     fn deserialize_update_response() {
-        let content = r#"<UpdateFolderResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
-                          xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
-                          xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
-                <m:ResponseMessages>
-                    <m:UpdateFolderResponseMessage ResponseClass="Success">
-                    <m:ResponseCode>NoError</m:ResponseCode>
-                    <m:Folders>
-                        <t:Folder>
-                        <t:FolderId Id="AAAlAFVz" ChangeKey="AQAAAB" />
-                        </t:Folder>
-                    </m:Folders>
-                    </m:UpdateFolderResponseMessage>
-                </m:ResponseMessages>
+        let content = r#"
+            <UpdateFolderResponse
+                xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
+                xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
+                xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
+              <m:ResponseMessages>
+                <m:UpdateFolderResponseMessage ResponseClass="Success">
+                  <m:ResponseCode>NoError</m:ResponseCode>
+                  <m:Folders>
+                    <t:Folder>
+                      <t:FolderId Id="AAAlAFVz" ChangeKey="AQAAAB" />
+                    </t:Folder>
+                  </m:Folders>
+                </m:UpdateFolderResponseMessage>
+              </m:ResponseMessages>
             </UpdateFolderResponse>"#;
 
         let expected = UpdateFolderResponse {


### PR DESCRIPTION
Use a consistent style for XML fixtures, deduplicate some logic, and make use of `Default` implementations in a few more places.

Feel free to request a different style for the XML, I just want something consistent.