### PR TITLE
Add Mailbox support to DistinguishedFolderId and calendar item fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "ews"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
- "ews_proc_macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ews_proc_macros",
  "quick-xml",
  "serde",
  "serde_path_to_error",
@@ -34,16 +34,6 @@ dependencies = [
 [[package]]
 name = "ews_proc_macros"
 version = "0.1.0"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "ews_proc_macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74a07e9809826ddfdd105cc32fbab30ca2a68d56406c7d1ab65e7e5ba666ab7"
 dependencies = [
  "quote",
  "syn",

--- a/ews/Cargo.toml
+++ b/ews/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [".github", ".vscode"]
 interop = []
 
 [dependencies]
-ews_proc_macros = "0.1.0"
+ews_proc_macros = { version = "0.1.0", path = "../ews_proc_macros" }
 quick-xml = { version = "0.31.0", features = ["serde", "serialize"] }
 serde = { version = "1.0.196", features = ["derive"] }
 serde_path_to_error = "0.1.11"

--- a/ews/src/types/common.rs
+++ b/ews/src/types/common.rs
@@ -324,7 +324,50 @@ pub enum BaseFolderId {
 
         #[xml_struct(attribute)]
         change_key: Option<String>,
+
+        /// The mailbox that owns this distinguished folder.
+        ///
+        /// Required when referencing a distinguished folder in a mailbox
+        /// other than the one associated with the account making the
+        /// request, e.g. a shared or resource mailbox.
+        ///
+        /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/distinguishedfolderid>.
+        #[xml_struct(ns_prefix = "t")]
+        mailbox: Option<Mailbox>,
     },
+}
+
+impl BaseFolderId {
+    /// Creates a [`BaseFolderId::FolderId`] referencing an arbitrary folder
+    /// by its identifier.
+    pub fn folder(id: impl Into<String>) -> Self {
+        BaseFolderId::FolderId {
+            id: id.into(),
+            change_key: None,
+        }
+    }
+
+    /// Creates a [`BaseFolderId::DistinguishedFolderId`] referencing a
+    /// well-known folder (e.g. `"calendar"` or `"inbox"`) in the requesting
+    /// account's own mailbox.
+    pub fn distinguished(id: impl Into<String>) -> Self {
+        BaseFolderId::DistinguishedFolderId {
+            id: id.into(),
+            change_key: None,
+            mailbox: None,
+        }
+    }
+
+    /// Creates a [`BaseFolderId::DistinguishedFolderId`] referencing a
+    /// well-known folder in another mailbox, e.g. a shared or resource
+    /// mailbox, identified by `mailbox`.
+    pub fn distinguished_in_mailbox(id: impl Into<String>, mailbox: Mailbox) -> Self {
+        BaseFolderId::DistinguishedFolderId {
+            id: id.into(),
+            change_key: None,
+            mailbox: Some(mailbox),
+        }
+    }
 }
 
 /// The unique identifier of a folder.
@@ -836,6 +879,55 @@ pub struct Message {
     /// This element was introduced in Exchange 2013.
     #[xml_struct(ns_prefix = "t")]
     pub flag: Option<Flag>,
+
+    /// The start time of a calendar item.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/start>
+    #[xml_struct(ns_prefix = "t")]
+    pub start: Option<DateTime>,
+
+    /// The end time of a calendar item.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/end>
+    #[xml_struct(ns_prefix = "t")]
+    pub end: Option<DateTime>,
+
+    /// The location of a calendar item.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/location>
+    #[xml_struct(ns_prefix = "t")]
+    pub location: Option<String>,
+
+    /// Whether a calendar item lasts all day.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/isalldayevent>
+    #[xml_struct(ns_prefix = "t")]
+    pub is_all_day_event: Option<bool>,
+
+    /// Whether a calendar item has been cancelled by its organizer.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/iscancelled>
+    #[xml_struct(ns_prefix = "t")]
+    pub is_cancelled: Option<bool>,
+
+    /// Whether a calendar item is a meeting (i.e. has attendees other than
+    /// its organizer).
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/ismeeting>
+    #[xml_struct(ns_prefix = "t")]
+    pub is_meeting: Option<bool>,
+
+    /// The free/busy status to publish for a calendar item.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/legacyfreebusystatus>
+    #[xml_struct(ns_prefix = "t")]
+    pub legacy_free_busy_status: Option<String>,
+
+    /// The organizer of a calendar item or meeting request.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/organizer>
+    #[xml_struct(ns_prefix = "t")]
+    pub organizer: Option<Recipient>,
 }
 
 /// An extended MAPI property of an Exchange item or folder.

--- a/ews/src/types/copy_folder.rs
+++ b/ews/src/types/copy_folder.rs
@@ -31,10 +31,7 @@ mod test {
     fn test_serialize_copy_folder() {
         let copy_folder = CopyFolder {
             inner: CopyMoveFolderData {
-                to_folder_id: BaseFolderId::DistinguishedFolderId {
-                    id: "inbox".to_string(),
-                    change_key: None,
-                },
+                to_folder_id: BaseFolderId::distinguished("inbox"),
                 folder_ids: vec![
                     BaseFolderId::FolderId {
                         id: "AS4A=".to_string(),
@@ -52,7 +49,7 @@ mod test {
             r#"
             <CopyFolder xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
               <ToFolderId>
-                <t:DistinguishedFolderId Id="inbox"/>
+                <t:DistinguishedFolderId Id="inbox"></t:DistinguishedFolderId>
               </ToFolderId>
               <FolderIds>
                 <t:FolderId Id="AS4A=" ChangeKey="fsVU4=="/>

--- a/ews/src/types/copy_item.rs
+++ b/ews/src/types/copy_item.rs
@@ -31,10 +31,7 @@ mod test {
     fn test_serialize_copy_item() {
         let request = CopyItem {
             inner: CopyMoveItemData {
-                to_folder_id: BaseFolderId::DistinguishedFolderId {
-                    id: "inbox".to_string(),
-                    change_key: None,
-                },
+                to_folder_id: BaseFolderId::distinguished("inbox"),
                 item_ids: vec![BaseItemId::ItemId {
                     id: "AS4AUnV=".to_string(),
                     change_key: None,
@@ -47,7 +44,7 @@ mod test {
             r#"
             <CopyItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
               <ToFolderId>
-                <t:DistinguishedFolderId Id="inbox"/>
+                <t:DistinguishedFolderId Id="inbox"></t:DistinguishedFolderId>
               </ToFolderId>
               <ItemIds>
                 <t:ItemId Id="AS4AUnV="/>

--- a/ews/src/types/find_item.rs
+++ b/ews/src/types/find_item.rs
@@ -84,7 +84,7 @@ pub struct RootFolder {
 mod tests {
     use crate::{
         test_utils::{assert_deserialized_content, assert_serialized_content, minify_xml},
-        BasePoint, BaseShape, Groups, ItemId, Items, Message, RealItem, ResponseClass,
+        BasePoint, BaseShape, Groups, ItemId, Items, Mailbox, Message, RealItem, ResponseClass,
         ResponseMessages,
     };
 
@@ -98,10 +98,7 @@ mod tests {
                 base_shape: BaseShape::IdOnly,
                 ..Default::default()
             },
-            parent_folder_ids: vec![BaseFolderId::DistinguishedFolderId {
-                id: "deleteditems".to_string(),
-                change_key: None,
-            }],
+            parent_folder_ids: vec![BaseFolderId::distinguished("deleteditems")],
             view: Some(View::IndexedPageItemView {
                 max_entries_returned: Some(6),
                 offset: 0,
@@ -117,7 +114,7 @@ mod tests {
               </ItemShape>
               <IndexedPageItemView MaxEntriesReturned="6" BasePoint="Beginning" Offset="0"/>
               <ParentFolderIds>
-                <t:DistinguishedFolderId Id="deleteditems"/>
+                <t:DistinguishedFolderId Id="deleteditems"></t:DistinguishedFolderId>
               </ParentFolderIds>
             </FindItem>"#,
         );
@@ -133,10 +130,7 @@ mod tests {
                 base_shape: BaseShape::IdOnly,
                 ..Default::default()
             },
-            parent_folder_ids: vec![BaseFolderId::DistinguishedFolderId {
-                id: "inbox".to_string(),
-                change_key: None,
-            }],
+            parent_folder_ids: vec![BaseFolderId::distinguished("inbox")],
             view: Some(View::FractionalPageItemView {
                 max_entries_returned: Some(12),
                 numerator: 2,
@@ -152,7 +146,7 @@ mod tests {
               </ItemShape>
               <FractionalPageItemView MaxEntriesReturned="12" Numerator="2" Denominator="3"/>
               <ParentFolderIds>
-                <t:DistinguishedFolderId Id="inbox"/>
+                <t:DistinguishedFolderId Id="inbox"></t:DistinguishedFolderId>
               </ParentFolderIds>
             </FindItem>"#,
         );
@@ -167,10 +161,7 @@ mod tests {
                 base_shape: BaseShape::IdOnly,
                 ..Default::default()
             },
-            parent_folder_ids: vec![BaseFolderId::DistinguishedFolderId {
-                id: "calendar".to_string(),
-                change_key: None,
-            }],
+            parent_folder_ids: vec![BaseFolderId::distinguished("calendar")],
             view: Some(View::CalendarView {
                 max_entries_returned: Some(2),
                 start_date: "2006-05-18T00:00:00-08:00".to_string(),
@@ -186,7 +177,49 @@ mod tests {
               </ItemShape>
               <CalendarView MaxEntriesReturned="2" StartDate="2006-05-18T00:00:00-08:00" EndDate="2006-05-19T00:00:00-08:00"/>
               <ParentFolderIds>
-                <t:DistinguishedFolderId Id="calendar"/>
+                <t:DistinguishedFolderId Id="calendar"></t:DistinguishedFolderId>
+              </ParentFolderIds>
+            </FindItem>"#,
+        );
+
+        assert_serialized_content(&find_item, "FindItem", &expected);
+    }
+
+    #[test]
+    fn test_serialize_find_item_calendar_view_with_mailbox() {
+        let find_item = FindItem {
+            traversal: Traversal::Shallow,
+            item_shape: ItemShape {
+                base_shape: BaseShape::IdOnly,
+                ..Default::default()
+            },
+            parent_folder_ids: vec![BaseFolderId::distinguished_in_mailbox(
+                "calendar",
+                Mailbox {
+                    email_address: Some("room@example.com".to_string()),
+                    ..Default::default()
+                },
+            )],
+            view: Some(View::CalendarView {
+                max_entries_returned: Some(2),
+                start_date: "2006-05-18T00:00:00-08:00".to_string(),
+                end_date: "2006-05-19T00:00:00-08:00".to_string(),
+            }),
+        };
+
+        let expected = minify_xml(
+            r#"
+            <FindItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" Traversal="Shallow">
+              <ItemShape>
+                <t:BaseShape>IdOnly</t:BaseShape>
+              </ItemShape>
+              <CalendarView MaxEntriesReturned="2" StartDate="2006-05-18T00:00:00-08:00" EndDate="2006-05-19T00:00:00-08:00"/>
+              <ParentFolderIds>
+                <t:DistinguishedFolderId Id="calendar">
+                  <t:Mailbox>
+                    <t:EmailAddress>room@example.com</t:EmailAddress>
+                  </t:Mailbox>
+                </t:DistinguishedFolderId>
               </ParentFolderIds>
             </FindItem>"#,
         );
@@ -202,10 +235,7 @@ mod tests {
                 base_shape: BaseShape::IdOnly,
                 ..Default::default()
             },
-            parent_folder_ids: vec![BaseFolderId::DistinguishedFolderId {
-                id: "contacts".to_string(),
-                change_key: None,
-            }],
+            parent_folder_ids: vec![BaseFolderId::distinguished("contacts")],
             view: Some(View::ContactsView {
                 max_entries_returned: Some(3),
                 initial_name: Some("Kelly Rollin".to_string()),
@@ -221,7 +251,7 @@ mod tests {
               </ItemShape>
               <ContactsView MaxEntriesReturned="3" InitialName="Kelly Rollin"/>
               <ParentFolderIds>
-                <t:DistinguishedFolderId Id="contacts"/>
+                <t:DistinguishedFolderId Id="contacts"></t:DistinguishedFolderId>
               </ParentFolderIds>
             </FindItem>"#,
         );

--- a/ews/src/types/move_folder.rs
+++ b/ews/src/types/move_folder.rs
@@ -31,10 +31,7 @@ mod test {
     fn test_serialize_move_folder() {
         let move_folder = MoveFolder {
             inner: CopyMoveFolderData {
-                to_folder_id: BaseFolderId::DistinguishedFolderId {
-                    id: "junkemail".to_string(),
-                    change_key: None,
-                },
+                to_folder_id: BaseFolderId::distinguished("junkemail"),
                 folder_ids: vec![BaseFolderId::FolderId {
                     id: "AScAc".to_string(),
                     change_key: None,
@@ -46,7 +43,7 @@ mod test {
             r#"
             <MoveFolder xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
               <ToFolderId>
-                <t:DistinguishedFolderId Id="junkemail"/>
+                <t:DistinguishedFolderId Id="junkemail"></t:DistinguishedFolderId>
               </ToFolderId>
               <FolderIds>
                 <t:FolderId Id="AScAc"/>

--- a/ews/src/types/move_item.rs
+++ b/ews/src/types/move_item.rs
@@ -35,10 +35,7 @@ mod test {
     fn test_serialize_move_item() {
         let move_item = MoveItem {
             inner: CopyMoveItemData {
-                to_folder_id: BaseFolderId::DistinguishedFolderId {
-                    id: "drafts".to_string(),
-                    change_key: None,
-                },
+                to_folder_id: BaseFolderId::distinguished("drafts"),
                 item_ids: vec![BaseItemId::ItemId {
                     id: "AAAtAEF/swbAAA=".to_string(),
                     change_key: Some("EwAAABYA/s4b".to_string()),
@@ -51,7 +48,7 @@ mod test {
             r#"
             <MoveItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
               <ToFolderId>
-                <t:DistinguishedFolderId Id="drafts"/>
+                <t:DistinguishedFolderId Id="drafts"></t:DistinguishedFolderId>
               </ToFolderId>
               <ItemIds>
                 <t:ItemId Id="AAAtAEF/swbAAA=" ChangeKey="EwAAABYA/s4b"/>


### PR DESCRIPTION
EWS requires a <t:Mailbox> child element on DistinguishedFolderId to target a folder in a mailbox other than the requesting account's own (e.g. a shared or resource calendar). This was previously unsupported, making it impossible to query a meeting room's calendar via FindItem.