### PR TITLE
Add support for meeting invitation attributes on CreateItem and UpdateItem

### DIFF
--- a/ews/src/types/common.rs
+++ b/ews/src/types/common.rs
@@ -202,6 +202,19 @@ pub enum MessageDisposition {
     SendAndSaveCopy,
 }
 
+/// Whether/how meeting invitations are sent to attendees.
+///
+/// This field is required for and only applicable to `CalendarItem` items.
+///
+/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/createitem#sendmeetinginvitations-attribute>
+#[derive(Clone, Copy, Debug, XmlSerialize)]
+#[xml_struct(text)]
+pub enum SendMeetingInvitations {
+    SendToNone,
+    SendOnlyToAll,
+    SendToAllAndSaveCopy,
+}
+
 /// The type of the value of a MAPI property.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/extendedfielduri#propertytype-attribute>

--- a/ews/src/types/common.rs
+++ b/ews/src/types/common.rs
@@ -215,6 +215,21 @@ pub enum SendMeetingInvitations {
     SendToAllAndSaveCopy,
 }
 
+/// Whether/how meeting invitations or cancellations are sent to attendees
+/// when updating a calendar item.
+///
+/// This field is required for and only applicable to `CalendarItem` items.
+///
+/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/updateitem#sendmeetinginvitationsorcancellations-attribute>
+#[derive(Clone, Copy, Debug, XmlSerialize)]
+#[xml_struct(text)]
+pub enum SendMeetingInvitationsOrCancellations {
+    SendToNone,
+    SendOnlyToAll,
+    SendToAllAndSaveCopy,
+    SendToChangedAndSaveCopy,
+}
+
 /// The type of the value of a MAPI property.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/extendedfielduri#propertytype-attribute>

--- a/ews/src/types/common.rs
+++ b/ews/src/types/common.rs
@@ -324,7 +324,50 @@ pub enum BaseFolderId {
 
         #[xml_struct(attribute)]
         change_key: Option<String>,
+
+        /// The mailbox that owns this distinguished folder.
+        ///
+        /// Required when referencing a distinguished folder in a mailbox
+        /// other than the one associated with the account making the
+        /// request, e.g. a shared or resource mailbox.
+        ///
+        /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/distinguishedfolderid>.
+        #[xml_struct(ns_prefix = "t")]
+        mailbox: Option<Mailbox>,
     },
+}
+
+impl BaseFolderId {
+    /// Creates a [`BaseFolderId::FolderId`] referencing an arbitrary folder
+    /// by its identifier.
+    pub fn new_folder(id: impl Into<String>) -> Self {
+        BaseFolderId::FolderId {
+            id: id.into(),
+            change_key: None,
+        }
+    }
+
+    /// Creates a [`BaseFolderId::DistinguishedFolderId`] referencing a
+    /// well-known folder (e.g. `"calendar"` or `"inbox"`) in the requesting
+    /// account's own mailbox.
+    pub fn new_distinguished(id: impl Into<String>) -> Self {
+        BaseFolderId::DistinguishedFolderId {
+            id: id.into(),
+            change_key: None,
+            mailbox: None,
+        }
+    }
+
+    /// Creates a [`BaseFolderId::DistinguishedFolderId`] referencing a
+    /// well-known folder in another mailbox, e.g. a shared or resource
+    /// mailbox, identified by `mailbox`.
+    pub fn new_distinguished_in_mailbox(id: impl Into<String>, mailbox: Mailbox) -> Self {
+        BaseFolderId::DistinguishedFolderId {
+            id: id.into(),
+            change_key: None,
+            mailbox: Some(mailbox),
+        }
+    }
 }
 
 /// The unique identifier of a folder.

--- a/ews/src/types/copy_folder.rs
+++ b/ews/src/types/copy_folder.rs
@@ -31,10 +31,7 @@ mod test {
     fn test_serialize_copy_folder() {
         let copy_folder = CopyFolder {
             inner: CopyMoveFolderData {
-                to_folder_id: BaseFolderId::DistinguishedFolderId {
-                    id: "inbox".to_string(),
-                    change_key: None,
-                },
+                to_folder_id: BaseFolderId::new_distinguished("inbox"),
                 folder_ids: vec![
                     BaseFolderId::FolderId {
                         id: "AS4A=".to_string(),
@@ -52,7 +49,7 @@ mod test {
             r#"
             <CopyFolder xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
               <ToFolderId>
-                <t:DistinguishedFolderId Id="inbox"/>
+                <t:DistinguishedFolderId Id="inbox"></t:DistinguishedFolderId>
               </ToFolderId>
               <FolderIds>
                 <t:FolderId Id="AS4A=" ChangeKey="fsVU4=="/>

--- a/ews/src/types/copy_item.rs
+++ b/ews/src/types/copy_item.rs
@@ -31,10 +31,7 @@ mod test {
     fn test_serialize_copy_item() {
         let request = CopyItem {
             inner: CopyMoveItemData {
-                to_folder_id: BaseFolderId::DistinguishedFolderId {
-                    id: "inbox".to_string(),
-                    change_key: None,
-                },
+                to_folder_id: BaseFolderId::new_distinguished("inbox"),
                 item_ids: vec![BaseItemId::ItemId {
                     id: "AS4AUnV=".to_string(),
                     change_key: None,
@@ -47,7 +44,7 @@ mod test {
             r#"
             <CopyItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
               <ToFolderId>
-                <t:DistinguishedFolderId Id="inbox"/>
+                <t:DistinguishedFolderId Id="inbox"></t:DistinguishedFolderId>
               </ToFolderId>
               <ItemIds>
                 <t:ItemId Id="AS4AUnV="/>

--- a/ews/src/types/create_item.rs
+++ b/ews/src/types/create_item.rs
@@ -5,7 +5,10 @@
 use ews_proc_macros::operation_response;
 use xml_struct::XmlSerialize;
 
-use crate::{BaseFolderId, ItemResponseMessage, MessageDisposition, RealItem, MESSAGES_NS_URI};
+use crate::{
+    BaseFolderId, ItemResponseMessage, MessageDisposition, RealItem, SendMeetingInvitations,
+    MESSAGES_NS_URI,
+};
 
 /// A request to create (and optionally send) one or more Exchange items.
 ///
@@ -24,6 +27,14 @@ pub struct CreateItem {
     #[xml_struct(attribute)]
     pub message_disposition: Option<MessageDisposition>,
 
+    /// Whether/how meeting invitations are sent to attendees.
+    ///
+    /// This field is required for and only applicable to calendar items.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/createitem#sendmeetinginvitations-attribute>
+    #[xml_struct(attribute)]
+    pub send_meeting_invitations: Option<SendMeetingInvitations>,
+
     /// The folder in which to store an item once it has been created.
     ///
     /// This is ignored if `message_disposition` is [`SendOnly`].
@@ -40,11 +51,56 @@ pub struct CreateItem {
 #[cfg(test)]
 mod test {
     use crate::{
-        test_utils::assert_deserialized_content, types::common::ItemResponseMessage, Items,
-        ResponseClass, ResponseMessages,
+        test_utils::{assert_deserialized_content, assert_serialized_content, minify_xml},
+        types::common::ItemResponseMessage,
+        BaseFolderId, Items, Message, MessageDisposition, RealItem, ResponseClass,
+        ResponseMessages, SendMeetingInvitations,
     };
 
-    use super::CreateItemResponse;
+    use super::{CreateItem, CreateItemResponse};
+
+    #[test]
+    fn test_serialize_create_item_send_meeting_invitations() {
+        let request = CreateItem {
+            message_disposition: None,
+            send_meeting_invitations: Some(SendMeetingInvitations::SendToAllAndSaveCopy),
+            saved_item_folder_id: Some(BaseFolderId::new_distinguished("calendar")),
+            items: vec![RealItem::CalendarItem(Message::default())],
+        };
+
+        let expected = minify_xml(
+            r#"
+            <CreateItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" SendMeetingInvitations="SendToAllAndSaveCopy">
+              <SavedItemFolderId>
+                <t:DistinguishedFolderId Id="calendar"></t:DistinguishedFolderId>
+              </SavedItemFolderId>
+              <Items>
+                <t:CalendarItem></t:CalendarItem>
+              </Items>
+            </CreateItem>"#,
+        );
+
+        assert_serialized_content(&request, "CreateItem", &expected);
+    }
+
+    #[test]
+    fn test_serialize_create_item_message_disposition() {
+        let request = CreateItem {
+            message_disposition: Some(MessageDisposition::SendAndSaveCopy),
+            send_meeting_invitations: None,
+            saved_item_folder_id: None,
+            items: vec![],
+        };
+
+        let expected = minify_xml(
+            r#"
+            <CreateItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" MessageDisposition="SendAndSaveCopy">
+              <Items></Items>
+            </CreateItem>"#,
+        );
+
+        assert_serialized_content(&request, "CreateItem", &expected);
+    }
 
     #[test]
     fn test_deserialize_create_item_response() {

--- a/ews/src/types/find_item.rs
+++ b/ews/src/types/find_item.rs
@@ -84,7 +84,7 @@ pub struct RootFolder {
 mod tests {
     use crate::{
         test_utils::{assert_deserialized_content, assert_serialized_content, minify_xml},
-        BasePoint, BaseShape, Groups, ItemId, Items, Message, RealItem, ResponseClass,
+        BasePoint, BaseShape, Groups, ItemId, Items, Mailbox, Message, RealItem, ResponseClass,
         ResponseMessages,
     };
 
@@ -98,10 +98,7 @@ mod tests {
                 base_shape: BaseShape::IdOnly,
                 ..Default::default()
             },
-            parent_folder_ids: vec![BaseFolderId::DistinguishedFolderId {
-                id: "deleteditems".to_string(),
-                change_key: None,
-            }],
+            parent_folder_ids: vec![BaseFolderId::new_distinguished("deleteditems")],
             view: Some(View::IndexedPageItemView {
                 max_entries_returned: Some(6),
                 offset: 0,
@@ -117,7 +114,7 @@ mod tests {
               </ItemShape>
               <IndexedPageItemView MaxEntriesReturned="6" BasePoint="Beginning" Offset="0"/>
               <ParentFolderIds>
-                <t:DistinguishedFolderId Id="deleteditems"/>
+                <t:DistinguishedFolderId Id="deleteditems"></t:DistinguishedFolderId>
               </ParentFolderIds>
             </FindItem>"#,
         );
@@ -133,10 +130,7 @@ mod tests {
                 base_shape: BaseShape::IdOnly,
                 ..Default::default()
             },
-            parent_folder_ids: vec![BaseFolderId::DistinguishedFolderId {
-                id: "inbox".to_string(),
-                change_key: None,
-            }],
+            parent_folder_ids: vec![BaseFolderId::new_distinguished("inbox")],
             view: Some(View::FractionalPageItemView {
                 max_entries_returned: Some(12),
                 numerator: 2,
@@ -152,7 +146,7 @@ mod tests {
               </ItemShape>
               <FractionalPageItemView MaxEntriesReturned="12" Numerator="2" Denominator="3"/>
               <ParentFolderIds>
-                <t:DistinguishedFolderId Id="inbox"/>
+                <t:DistinguishedFolderId Id="inbox"></t:DistinguishedFolderId>
               </ParentFolderIds>
             </FindItem>"#,
         );
@@ -167,10 +161,7 @@ mod tests {
                 base_shape: BaseShape::IdOnly,
                 ..Default::default()
             },
-            parent_folder_ids: vec![BaseFolderId::DistinguishedFolderId {
-                id: "calendar".to_string(),
-                change_key: None,
-            }],
+            parent_folder_ids: vec![BaseFolderId::new_distinguished("calendar")],
             view: Some(View::CalendarView {
                 max_entries_returned: Some(2),
                 start_date: "2006-05-18T00:00:00-08:00".to_string(),
@@ -186,7 +177,49 @@ mod tests {
               </ItemShape>
               <CalendarView MaxEntriesReturned="2" StartDate="2006-05-18T00:00:00-08:00" EndDate="2006-05-19T00:00:00-08:00"/>
               <ParentFolderIds>
-                <t:DistinguishedFolderId Id="calendar"/>
+                <t:DistinguishedFolderId Id="calendar"></t:DistinguishedFolderId>
+              </ParentFolderIds>
+            </FindItem>"#,
+        );
+
+        assert_serialized_content(&find_item, "FindItem", &expected);
+    }
+
+    #[test]
+    fn test_serialize_find_item_calendar_view_with_mailbox() {
+        let find_item = FindItem {
+            traversal: Traversal::Shallow,
+            item_shape: ItemShape {
+                base_shape: BaseShape::IdOnly,
+                ..Default::default()
+            },
+            parent_folder_ids: vec![BaseFolderId::new_distinguished_in_mailbox(
+                "calendar",
+                Mailbox {
+                    email_address: Some("room@example.com".to_string()),
+                    ..Default::default()
+                },
+            )],
+            view: Some(View::CalendarView {
+                max_entries_returned: Some(2),
+                start_date: "2006-05-18T00:00:00-08:00".to_string(),
+                end_date: "2006-05-19T00:00:00-08:00".to_string(),
+            }),
+        };
+
+        let expected = minify_xml(
+            r#"
+            <FindItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" Traversal="Shallow">
+              <ItemShape>
+                <t:BaseShape>IdOnly</t:BaseShape>
+              </ItemShape>
+              <CalendarView MaxEntriesReturned="2" StartDate="2006-05-18T00:00:00-08:00" EndDate="2006-05-19T00:00:00-08:00"/>
+              <ParentFolderIds>
+                <t:DistinguishedFolderId Id="calendar">
+                  <t:Mailbox>
+                    <t:EmailAddress>room@example.com</t:EmailAddress>
+                  </t:Mailbox>
+                </t:DistinguishedFolderId>
               </ParentFolderIds>
             </FindItem>"#,
         );
@@ -202,10 +235,7 @@ mod tests {
                 base_shape: BaseShape::IdOnly,
                 ..Default::default()
             },
-            parent_folder_ids: vec![BaseFolderId::DistinguishedFolderId {
-                id: "contacts".to_string(),
-                change_key: None,
-            }],
+            parent_folder_ids: vec![BaseFolderId::new_distinguished("contacts")],
             view: Some(View::ContactsView {
                 max_entries_returned: Some(3),
                 initial_name: Some("Kelly Rollin".to_string()),
@@ -221,7 +251,7 @@ mod tests {
               </ItemShape>
               <ContactsView MaxEntriesReturned="3" InitialName="Kelly Rollin"/>
               <ParentFolderIds>
-                <t:DistinguishedFolderId Id="contacts"/>
+                <t:DistinguishedFolderId Id="contacts"></t:DistinguishedFolderId>
               </ParentFolderIds>
             </FindItem>"#,
         );

--- a/ews/src/types/move_folder.rs
+++ b/ews/src/types/move_folder.rs
@@ -31,10 +31,7 @@ mod test {
     fn test_serialize_move_folder() {
         let move_folder = MoveFolder {
             inner: CopyMoveFolderData {
-                to_folder_id: BaseFolderId::DistinguishedFolderId {
-                    id: "junkemail".to_string(),
-                    change_key: None,
-                },
+                to_folder_id: BaseFolderId::new_distinguished("junkemail"),
                 folder_ids: vec![BaseFolderId::FolderId {
                     id: "AScAc".to_string(),
                     change_key: None,
@@ -46,7 +43,7 @@ mod test {
             r#"
             <MoveFolder xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
               <ToFolderId>
-                <t:DistinguishedFolderId Id="junkemail"/>
+                <t:DistinguishedFolderId Id="junkemail"></t:DistinguishedFolderId>
               </ToFolderId>
               <FolderIds>
                 <t:FolderId Id="AScAc"/>

--- a/ews/src/types/move_item.rs
+++ b/ews/src/types/move_item.rs
@@ -35,10 +35,7 @@ mod test {
     fn test_serialize_move_item() {
         let move_item = MoveItem {
             inner: CopyMoveItemData {
-                to_folder_id: BaseFolderId::DistinguishedFolderId {
-                    id: "drafts".to_string(),
-                    change_key: None,
-                },
+                to_folder_id: BaseFolderId::new_distinguished("drafts"),
                 item_ids: vec![BaseItemId::ItemId {
                     id: "AAAtAEF/swbAAA=".to_string(),
                     change_key: Some("EwAAABYA/s4b".to_string()),
@@ -51,7 +48,7 @@ mod test {
             r#"
             <MoveItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
               <ToFolderId>
-                <t:DistinguishedFolderId Id="drafts"/>
+                <t:DistinguishedFolderId Id="drafts"></t:DistinguishedFolderId>
               </ToFolderId>
               <ItemIds>
                 <t:ItemId Id="AAAtAEF/swbAAA=" ChangeKey="EwAAABYA/s4b"/>

--- a/ews/src/types/update_item.rs
+++ b/ews/src/types/update_item.rs
@@ -6,7 +6,9 @@ use ews_proc_macros::operation_response;
 use serde::Deserialize;
 use xml_struct::XmlSerialize;
 
-use crate::types::common::{BaseItemId, Message, MessageDisposition, PathToElement};
+use crate::types::common::{
+    BaseItemId, Message, MessageDisposition, PathToElement, SendMeetingInvitationsOrCancellations,
+};
 use crate::{Items, MESSAGES_NS_URI};
 
 /// A request to update properties of one or more Exchange items.
@@ -34,6 +36,15 @@ pub struct UpdateItem {
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/updateitem#conflictresolution-attribute>
     #[xml_struct(attribute)]
     pub conflict_resolution: Option<ConflictResolution>,
+
+    /// Whether/how meeting invitations or cancellations are sent to
+    /// attendees.
+    ///
+    /// Required when updating calendar items, otherwise it has no effect.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/updateitem#sendmeetinginvitationsorcancellations-attribute>
+    #[xml_struct(attribute)]
+    pub send_meeting_invitations_or_cancellations: Option<SendMeetingInvitationsOrCancellations>,
 
     /// A list of items and their corresponding updates.
     ///
@@ -111,4 +122,60 @@ pub enum ItemChangeDescription {
         #[xml_struct(ns_prefix = "t")]
         message: Message,
     },
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        test_utils::{assert_serialized_content, minify_xml},
+        BaseItemId, MessageDisposition, PathToElement, SendMeetingInvitationsOrCancellations,
+    };
+
+    use super::{ItemChange, ItemChangeDescription, ItemChangeInner, UpdateItem, Updates};
+
+    #[test]
+    fn test_serialize_update_item_send_meeting_invitations_or_cancellations() {
+        let request = UpdateItem {
+            message_disposition: MessageDisposition::SaveOnly,
+            conflict_resolution: None,
+            send_meeting_invitations_or_cancellations: Some(
+                SendMeetingInvitationsOrCancellations::SendToNone,
+            ),
+            item_changes: vec![ItemChange {
+                item_change: ItemChangeInner {
+                    item_id: BaseItemId::ItemId {
+                        id: "id".to_string(),
+                        change_key: None,
+                    },
+                    updates: Updates {
+                        inner: vec![ItemChangeDescription::SetItemField {
+                            field_uri: PathToElement::FieldURI {
+                                field_URI: "calendar:End".to_string(),
+                            },
+                            message: Default::default(),
+                        }],
+                    },
+                },
+            }],
+        };
+
+        let expected = minify_xml(
+            r#"
+            <UpdateItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" MessageDisposition="SaveOnly" SendMeetingInvitationsOrCancellations="SendToNone">
+              <ItemChanges>
+                <t:ItemChange>
+                  <t:ItemId Id="id"/>
+                  <t:Updates>
+                    <t:SetItemField>
+                      <t:FieldURI FieldURI="calendar:End"/>
+                      <t:Message></t:Message>
+                    </t:SetItemField>
+                  </t:Updates>
+                </t:ItemChange>
+              </ItemChanges>
+            </UpdateItem>"#,
+        );
+
+        assert_serialized_content(&request, "UpdateItem", &expected);
+    }
 }


### PR DESCRIPTION
This PR adds support for the following EWS attributes:

* `SendMeetingInvitations` on `CreateItem`
* `SendMeetingInvitationsOrCancellations` on `UpdateItem`

These attributes are required when working with calendar items.

Without `SendMeetingInvitations`, Exchange rejects `CreateItem` requests with the `ErrorSendMeetingInvitationsRequired` error.

Similarly, `UpdateItem` requests for calendar items must include `SendMeetingInvitationsOrCancellations`; otherwise Exchange returns `ErrorSendMeetingInvitationsOrCancellationsRequired`.