### PR TITLE
Handle attribute-only elements in MessageXml

### DIFF
--- a/ews/src/types/common/message_xml.rs
+++ b/ews/src/types/common/message_xml.rs
@@ -48,6 +48,14 @@ pub struct MessageXmlTagged {
     pub value: String,
 }
 
+/// A tag with one or more XML attributes and no text content, e.g.
+/// `<t:FieldURI FieldURI="calendar:IsMeeting"/>`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MessageXmlAttributed {
+    pub name: String,
+    pub attributes: Vec<(String, String)>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MessageXmlElements {
     pub elements: Vec<MessageXmlElement>,
@@ -57,6 +65,7 @@ pub struct MessageXmlElements {
 pub enum MessageXmlElement {
     MessageXmlTagged(MessageXmlTagged),
     MessageXmlValue(MessageXmlValue),
+    MessageXmlAttributed(MessageXmlAttributed),
 }
 
 /// Data associated with a [`ResponseCode::ErrorServerBusy`](crate::response::ResponseCode::ErrorServerBusy).
@@ -122,13 +131,75 @@ impl MessageXmlElementsVisitor {
 }
 
 /// An internal helper type used in the [`MessageXmlElementsVisitor`] to extract the
-/// text of an element while discarding the [`TYPES_NS_URI`](crate::TYPES_NS_URI) XML namespace declaration.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+/// content of an element: its text, the [`TYPES_NS_URI`](crate::TYPES_NS_URI) XML
+/// namespace declaration, or, if it has neither, its XML attributes (e.g.
+/// `<t:FieldURI FieldURI="calendar:IsMeeting"/>`).
+#[derive(Debug, Clone, PartialEq)]
 enum Text {
-    #[serde(rename = "$text")]
-    Text(String),
-    #[serde(rename = "http://schemas.microsoft.com/exchange/services/2006/types")]
+    Content(String),
     TypesNsDeclaration,
+    Attributed(Vec<(String, String)>),
+}
+
+struct TextVisitor;
+
+impl<'de> Visitor<'de> for TextVisitor {
+    type Value = Text;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("element text, a namespace declaration, or element attributes")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        if v == "http://schemas.microsoft.com/exchange/services/2006/types" {
+            Ok(Text::TypesNsDeclaration)
+        } else {
+            Ok(Text::Content(v.to_string()))
+        }
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.visit_str(&v)
+    }
+
+    fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
+    where
+        M: MapAccess<'de>,
+    {
+        let mut attributes = vec![];
+
+        while let Some(key) = access.next_key::<String>()? {
+            if key == "$text" {
+                let value = access.next_value::<String>()?;
+                return Ok(Text::Content(value));
+            } else if key == "http://schemas.microsoft.com/exchange/services/2006/types" {
+                access.next_value::<de::IgnoredAny>()?;
+                return Ok(Text::TypesNsDeclaration);
+            } else if let Some(attribute_name) = key.strip_prefix('@') {
+                let value = access.next_value::<String>()?;
+                attributes.push((attribute_name.to_string(), value));
+            } else {
+                access.next_value::<de::IgnoredAny>()?;
+            }
+        }
+
+        Ok(Text::Attributed(attributes))
+    }
+}
+
+impl<'de> Deserialize<'de> for Text {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(TextVisitor)
+    }
 }
 
 impl<'de> Visitor<'de> for MessageXmlElementsVisitor {
@@ -148,9 +219,21 @@ impl<'de> Visitor<'de> for MessageXmlElementsVisitor {
             if name.as_str() == "Value" {
                 let element = access.next_value::<MessageXmlValue>()?;
                 elements.push(MessageXmlElement::MessageXmlValue(element));
-            } else if let Text::Text(value) = access.next_value::<Text>()? {
-                let element = MessageXmlTagged { name, value };
-                elements.push(MessageXmlElement::MessageXmlTagged(element));
+            } else {
+                match access.next_value::<Text>()? {
+                    Text::Content(value) => {
+                        elements.push(MessageXmlElement::MessageXmlTagged(MessageXmlTagged {
+                            name,
+                            value,
+                        }));
+                    }
+                    Text::TypesNsDeclaration => {}
+                    Text::Attributed(attributes) => {
+                        elements.push(MessageXmlElement::MessageXmlAttributed(
+                            MessageXmlAttributed { name, attributes },
+                        ));
+                    }
+                }
             }
         }
 

--- a/ews/src/types/soap.rs
+++ b/ews/src/types/soap.rs
@@ -197,8 +197,8 @@ mod tests {
         sync_folder_items::SyncFolderItemsResponse,
         types::{
             common::message_xml::{
-                MessageXmlElement, MessageXmlElements, MessageXmlTagged, MessageXmlValue,
-                ServerBusy,
+                MessageXmlAttributed, MessageXmlElement, MessageXmlElements, MessageXmlTagged,
+                MessageXmlValue, ServerBusy,
             },
             sealed::EnvelopeBodyContents,
         },
@@ -373,6 +373,75 @@ mod tests {
             assert_eq!(
                 elements, expected,
                 "message XML should list all tags in order"
+            );
+        } else {
+            panic!("error should be request fault, got: {err:?}");
+        }
+    }
+
+    #[test]
+    fn deserialize_envelope_with_invalid_property_set_fault() {
+        // This XML is based on a real `ErrorInvalidPropertySet` response from
+        // Exchange, where `MessageXml` contains a tag with an XML attribute
+        // and no text content.
+        let xml = r#"
+            <?xml version="1.0" encoding="utf-8"?>
+            <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+              <s:Body>
+                <s:Fault>
+                  <faultcode xmlns:a="http://schemas.microsoft.com/exchange/services/2006/types">a:ErrorInvalidPropertySet</faultcode>
+                  <faultstring xml:lang="en-US">Set action is invalid for property.</faultstring>
+                  <detail>
+                    <e:ResponseCode xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">ErrorInvalidPropertySet</e:ResponseCode>
+                    <e:Message xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">Set action is invalid for property.</e:Message>
+                    <t:MessageXml xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+                      <t:FieldURI FieldURI="calendar:IsMeeting"/>
+                    </t:MessageXml>
+                  </detail>
+                </s:Fault>
+              </s:Body>
+            </s:Envelope>"#;
+
+        let err = <Envelope<FooResponse>>::from_xml_document(xml.as_bytes())
+            .expect_err("should return error when body contains fault");
+
+        if let Error::RequestFault(fault) = err {
+            assert_eq!(
+                fault.faultstring, "Set action is invalid for property.",
+                "fault string should match original document"
+            );
+
+            let detail = fault.detail.expect("fault detail should be present");
+            assert_eq!(
+                detail.response_code,
+                Some(ResponseCode::ErrorInvalidPropertySet),
+                "response code should match original document"
+            );
+            assert_eq!(
+                detail.message,
+                Some("Set action is invalid for property.".to_string()),
+                "error message should match original document"
+            );
+
+            let message_xml = detail.message_xml.expect("message XML should be present");
+
+            let MessageXml::Other(elements) = message_xml else {
+                panic!("this message XML should only have bare tags")
+            };
+            let expected = MessageXmlElements {
+                elements: vec![MessageXmlElement::MessageXmlAttributed(
+                    MessageXmlAttributed {
+                        name: "FieldURI".to_string(),
+                        attributes: vec![(
+                            "FieldURI".to_string(),
+                            "calendar:IsMeeting".to_string(),
+                        )],
+                    },
+                )],
+            };
+            assert_eq!(
+                elements, expected,
+                "message XML should list the attributed tag"
             );
         } else {
             panic!("error should be request fault, got: {err:?}");


### PR DESCRIPTION
EWS can return `MessageXml` content as a tag with an XML attribute and no text, e.g. `<t:FieldURI FieldURI="calendar:IsMeeting"/>`, for `ErrorInvalidPropertySet` responses. The `Text` helper used to parse MessageXml's child elements only recognized plain text content and the xmlns namespace declaration, so this shape caused a deserialization error that propagated up and broke parsing of the entire SOAP envelope, losing the actual error message text (see `deserialize_envelope_with_invalid_property_set_fault`).

Add a `MessageXmlAttributed` variant to capture tag name and attributes for this case, and rewrite the Text helper as a manual Deserialize Visitor implementation to support it.