### PR TITLE
Fix SetItemField to wrap calendar item updates in CalendarItem

### DIFF
--- a/ews/src/types/common.rs
+++ b/ews/src/types/common.rs
@@ -130,6 +130,16 @@ pub enum PathToElement {
     },
 }
 
+impl PathToElement {
+    /// Creates a [`PathToElement::FieldURI`] referencing a property by its
+    /// well-known string identifier (e.g. `"calendar:End"`).
+    pub fn new_field_uri(uri: impl Into<String>) -> Self {
+        PathToElement::FieldURI {
+            field_URI: uri.into(),
+        }
+    }
+}
+
 /// The identifier for an extended MAPI property.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/extendedfielduri>

--- a/ews/src/types/common.rs
+++ b/ews/src/types/common.rs
@@ -836,6 +836,79 @@ pub struct Message {
     /// This element was introduced in Exchange 2013.
     #[xml_struct(ns_prefix = "t")]
     pub flag: Option<Flag>,
+
+    /// The start time of a calendar item.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/start>
+    #[xml_struct(ns_prefix = "t")]
+    pub start: Option<DateTime>,
+
+    /// The end time of a calendar item.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/end>
+    #[xml_struct(ns_prefix = "t")]
+    pub end: Option<DateTime>,
+
+    /// The location of a calendar item.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/location>
+    #[xml_struct(ns_prefix = "t")]
+    pub location: Option<String>,
+
+    /// Whether a calendar item lasts all day.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/isalldayevent>
+    #[xml_struct(ns_prefix = "t")]
+    pub is_all_day_event: Option<bool>,
+
+    /// Whether a calendar item has been cancelled by its organizer.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/iscancelled>
+    #[xml_struct(ns_prefix = "t")]
+    pub is_cancelled: Option<bool>,
+
+    /// Whether a calendar item is a meeting (i.e. has attendees other than
+    /// its organizer).
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/ismeeting>
+    #[xml_struct(ns_prefix = "t")]
+    pub is_meeting: Option<bool>,
+
+    /// Whether a calendar item is recurring.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/isrecurring>
+    #[xml_struct(ns_prefix = "t")]
+    pub is_recurring: Option<bool>,
+
+    /// The free/busy status to publish for a calendar item.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/legacyfreebusystatus>
+    #[xml_struct(ns_prefix = "t")]
+    pub legacy_free_busy_status: Option<String>,
+
+    /// The organizer of a calendar item or meeting request.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/organizer>
+    #[xml_struct(ns_prefix = "t")]
+    pub organizer: Option<Recipient>,
+
+    /// The state of a calendar item, represented as a bitmask.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/appointmentstate>
+    #[xml_struct(ns_prefix = "t")]
+    pub appointment_state: Option<usize>,
+
+    /// Whether a calendar item is an online meeting.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/isonlinemeeting>
+    #[xml_struct(ns_prefix = "t")]
+    pub is_online_meeting: Option<bool>,
+
+    /// Whether the user requesting the calendar item is the organizer.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/isorganizer>
+    #[xml_struct(ns_prefix = "t")]
+    pub is_organizer: Option<bool>,
 }
 
 /// An extended MAPI property of an Exchange item or folder.
@@ -1551,6 +1624,91 @@ mod tests {
                 due_date: Some("2026-01-26T23:00:00Z".to_string()),
                 complete_date: None,
             }),
+            ..Default::default()
+        };
+
+        assert_deserialized_content(content, expected);
+    }
+
+    #[test]
+    fn test_serialize_message_calendar_fields() {
+        let message = Message {
+            start: Some(DateTime(
+                OffsetDateTime::parse("2026-06-26T17:54:39Z", &Iso8601::DEFAULT).unwrap(),
+            )),
+            end: Some(DateTime(
+                OffsetDateTime::parse("2026-06-26T18:54:39Z", &Iso8601::DEFAULT).unwrap(),
+            )),
+            location: Some("Room 42".to_string()),
+            is_all_day_event: Some(false),
+            is_cancelled: Some(false),
+            is_meeting: Some(true),
+            is_recurring: Some(false),
+            legacy_free_busy_status: Some("Busy".to_string()),
+            organizer: Some(Recipient {
+                mailbox: Mailbox {
+                    name: Some("Alice Test".to_string()),
+                    email_address: Some("alice@test.com".to_string()),
+                    ..Default::default()
+                },
+            }),
+            appointment_state: Some(1),
+            is_online_meeting: Some(false),
+            is_organizer: Some(true),
+            ..Default::default()
+        };
+
+        let expected = r#"<Message><t:Start>2026-06-26T17:54:39.000000000Z</t:Start><t:End>2026-06-26T18:54:39.000000000Z</t:End><t:Location>Room 42</t:Location><t:IsAllDayEvent>false</t:IsAllDayEvent><t:IsCancelled>false</t:IsCancelled><t:IsMeeting>true</t:IsMeeting><t:IsRecurring>false</t:IsRecurring><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:Organizer><t:Mailbox><t:Name>Alice Test</t:Name><t:EmailAddress>alice@test.com</t:EmailAddress></t:Mailbox></t:Organizer><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting><t:IsOrganizer>true</t:IsOrganizer></Message>"#;
+
+        assert_serialized_content(&message, "Message", expected);
+    }
+
+    #[test]
+    fn test_deserialize_message_calendar_fields() {
+        let content = r#"
+            <t:Message>
+              <t:Start>2026-06-26T17:54:39Z</t:Start>
+              <t:End>2026-06-26T18:54:39Z</t:End>
+              <t:Location>Room 42</t:Location>
+              <t:IsAllDayEvent>false</t:IsAllDayEvent>
+              <t:IsCancelled>false</t:IsCancelled>
+              <t:IsMeeting>true</t:IsMeeting>
+              <t:IsRecurring>false</t:IsRecurring>
+              <t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus>
+              <t:Organizer>
+                <t:Mailbox>
+                  <t:Name>Alice Test</t:Name>
+                  <t:EmailAddress>alice@test.com</t:EmailAddress>
+                </t:Mailbox>
+              </t:Organizer>
+              <t:AppointmentState>1</t:AppointmentState>
+              <t:IsOnlineMeeting>false</t:IsOnlineMeeting>
+              <t:IsOrganizer>true</t:IsOrganizer>
+            </t:Message>"#;
+
+        let expected = Message {
+            start: Some(DateTime(
+                OffsetDateTime::parse("2026-06-26T17:54:39Z", &Iso8601::DEFAULT).unwrap(),
+            )),
+            end: Some(DateTime(
+                OffsetDateTime::parse("2026-06-26T18:54:39Z", &Iso8601::DEFAULT).unwrap(),
+            )),
+            location: Some("Room 42".to_string()),
+            is_all_day_event: Some(false),
+            is_cancelled: Some(false),
+            is_meeting: Some(true),
+            is_recurring: Some(false),
+            legacy_free_busy_status: Some("Busy".to_string()),
+            organizer: Some(Recipient {
+                mailbox: Mailbox {
+                    name: Some("Alice Test".to_string()),
+                    email_address: Some("alice@test.com".to_string()),
+                    ..Default::default()
+                },
+            }),
+            appointment_state: Some(1),
+            is_online_meeting: Some(false),
+            is_organizer: Some(true),
             ..Default::default()
         };
 

--- a/ews/src/types/common.rs
+++ b/ews/src/types/common.rs
@@ -202,6 +202,19 @@ pub enum MessageDisposition {
     SendAndSaveCopy,
 }
 
+/// Whether/how meeting invitations are sent to attendees.
+///
+/// This field is required for and only applicable to `CalendarItem` items.
+///
+/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/createitem#sendmeetinginvitations-attribute>
+#[derive(Clone, Copy, Debug, XmlSerialize)]
+#[xml_struct(text)]
+pub enum SendMeetingInvitations {
+    SendToNone,
+    SendOnlyToAll,
+    SendToAllAndSaveCopy,
+}
+
 /// The type of the value of a MAPI property.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/extendedfielduri#propertytype-attribute>

--- a/ews/src/types/common.rs
+++ b/ews/src/types/common.rs
@@ -215,6 +215,21 @@ pub enum SendMeetingInvitations {
     SendToAllAndSaveCopy,
 }
 
+/// Whether/how meeting invitations or cancellations are sent to attendees
+/// when updating a calendar item.
+///
+/// This field is required for and only applicable to `CalendarItem` items.
+///
+/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/updateitem#sendmeetinginvitationsorcancellations-attribute>
+#[derive(Clone, Copy, Debug, XmlSerialize)]
+#[xml_struct(text)]
+pub enum SendMeetingInvitationsOrCancellations {
+    SendToNone,
+    SendOnlyToAll,
+    SendToAllAndSaveCopy,
+    SendToChangedAndSaveCopy,
+}
+
 /// The type of the value of a MAPI property.
 ///
 /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/extendedfielduri#propertytype-attribute>

--- a/ews/src/types/common.rs
+++ b/ews/src/types/common.rs
@@ -324,7 +324,50 @@ pub enum BaseFolderId {
 
         #[xml_struct(attribute)]
         change_key: Option<String>,
+
+        /// The mailbox that owns this distinguished folder.
+        ///
+        /// Required when referencing a distinguished folder in a mailbox
+        /// other than the one associated with the account making the
+        /// request, e.g. a shared or resource mailbox.
+        ///
+        /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/distinguishedfolderid>.
+        #[xml_struct(ns_prefix = "t")]
+        mailbox: Option<Mailbox>,
     },
+}
+
+impl BaseFolderId {
+    /// Creates a [`BaseFolderId::FolderId`] referencing an arbitrary folder
+    /// by its identifier.
+    pub fn new_folder(id: impl Into<String>) -> Self {
+        BaseFolderId::FolderId {
+            id: id.into(),
+            change_key: None,
+        }
+    }
+
+    /// Creates a [`BaseFolderId::DistinguishedFolderId`] referencing a
+    /// well-known folder (e.g. `"calendar"` or `"inbox"`) in the requesting
+    /// account's own mailbox.
+    pub fn new_distinguished(id: impl Into<String>) -> Self {
+        BaseFolderId::DistinguishedFolderId {
+            id: id.into(),
+            change_key: None,
+            mailbox: None,
+        }
+    }
+
+    /// Creates a [`BaseFolderId::DistinguishedFolderId`] referencing a
+    /// well-known folder in another mailbox, e.g. a shared or resource
+    /// mailbox, identified by `mailbox`.
+    pub fn new_distinguished_in_mailbox(id: impl Into<String>, mailbox: Mailbox) -> Self {
+        BaseFolderId::DistinguishedFolderId {
+            id: id.into(),
+            change_key: None,
+            mailbox: Some(mailbox),
+        }
+    }
 }
 
 /// The unique identifier of a folder.

--- a/ews/src/types/copy_folder.rs
+++ b/ews/src/types/copy_folder.rs
@@ -31,10 +31,7 @@ mod test {
     fn test_serialize_copy_folder() {
         let copy_folder = CopyFolder {
             inner: CopyMoveFolderData {
-                to_folder_id: BaseFolderId::DistinguishedFolderId {
-                    id: "inbox".to_string(),
-                    change_key: None,
-                },
+                to_folder_id: BaseFolderId::new_distinguished("inbox"),
                 folder_ids: vec![
                     BaseFolderId::FolderId {
                         id: "AS4A=".to_string(),
@@ -52,7 +49,7 @@ mod test {
             r#"
             <CopyFolder xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
               <ToFolderId>
-                <t:DistinguishedFolderId Id="inbox"/>
+                <t:DistinguishedFolderId Id="inbox"></t:DistinguishedFolderId>
               </ToFolderId>
               <FolderIds>
                 <t:FolderId Id="AS4A=" ChangeKey="fsVU4=="/>

--- a/ews/src/types/copy_item.rs
+++ b/ews/src/types/copy_item.rs
@@ -31,10 +31,7 @@ mod test {
     fn test_serialize_copy_item() {
         let request = CopyItem {
             inner: CopyMoveItemData {
-                to_folder_id: BaseFolderId::DistinguishedFolderId {
-                    id: "inbox".to_string(),
-                    change_key: None,
-                },
+                to_folder_id: BaseFolderId::new_distinguished("inbox"),
                 item_ids: vec![BaseItemId::ItemId {
                     id: "AS4AUnV=".to_string(),
                     change_key: None,
@@ -47,7 +44,7 @@ mod test {
             r#"
             <CopyItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
               <ToFolderId>
-                <t:DistinguishedFolderId Id="inbox"/>
+                <t:DistinguishedFolderId Id="inbox"></t:DistinguishedFolderId>
               </ToFolderId>
               <ItemIds>
                 <t:ItemId Id="AS4AUnV="/>

--- a/ews/src/types/create_item.rs
+++ b/ews/src/types/create_item.rs
@@ -5,7 +5,10 @@
 use ews_proc_macros::operation_response;
 use xml_struct::XmlSerialize;
 
-use crate::{BaseFolderId, ItemResponseMessage, MessageDisposition, RealItem, MESSAGES_NS_URI};
+use crate::{
+    BaseFolderId, ItemResponseMessage, MessageDisposition, RealItem, SendMeetingInvitations,
+    MESSAGES_NS_URI,
+};
 
 /// A request to create (and optionally send) one or more Exchange items.
 ///
@@ -24,6 +27,14 @@ pub struct CreateItem {
     #[xml_struct(attribute)]
     pub message_disposition: Option<MessageDisposition>,
 
+    /// Whether/how meeting invitations are sent to attendees.
+    ///
+    /// This field is required for and only applicable to calendar items.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/createitem#sendmeetinginvitations-attribute>
+    #[xml_struct(attribute)]
+    pub send_meeting_invitations: Option<SendMeetingInvitations>,
+
     /// The folder in which to store an item once it has been created.
     ///
     /// This is ignored if `message_disposition` is [`SendOnly`].
@@ -40,11 +51,56 @@ pub struct CreateItem {
 #[cfg(test)]
 mod test {
     use crate::{
-        test_utils::assert_deserialized_content, types::common::ItemResponseMessage, Items,
-        ResponseClass, ResponseMessages,
+        test_utils::{assert_deserialized_content, assert_serialized_content, minify_xml},
+        types::common::ItemResponseMessage,
+        BaseFolderId, Items, Message, MessageDisposition, RealItem, ResponseClass,
+        ResponseMessages, SendMeetingInvitations,
     };
 
-    use super::CreateItemResponse;
+    use super::{CreateItem, CreateItemResponse};
+
+    #[test]
+    fn test_serialize_create_item_send_meeting_invitations() {
+        let request = CreateItem {
+            message_disposition: None,
+            send_meeting_invitations: Some(SendMeetingInvitations::SendToAllAndSaveCopy),
+            saved_item_folder_id: Some(BaseFolderId::new_distinguished("calendar")),
+            items: vec![RealItem::CalendarItem(Message::default())],
+        };
+
+        let expected = minify_xml(
+            r#"
+            <CreateItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" SendMeetingInvitations="SendToAllAndSaveCopy">
+              <SavedItemFolderId>
+                <t:DistinguishedFolderId Id="calendar"></t:DistinguishedFolderId>
+              </SavedItemFolderId>
+              <Items>
+                <t:CalendarItem></t:CalendarItem>
+              </Items>
+            </CreateItem>"#,
+        );
+
+        assert_serialized_content(&request, "CreateItem", &expected);
+    }
+
+    #[test]
+    fn test_serialize_create_item_message_disposition() {
+        let request = CreateItem {
+            message_disposition: Some(MessageDisposition::SendAndSaveCopy),
+            send_meeting_invitations: None,
+            saved_item_folder_id: None,
+            items: vec![],
+        };
+
+        let expected = minify_xml(
+            r#"
+            <CreateItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" MessageDisposition="SendAndSaveCopy">
+              <Items></Items>
+            </CreateItem>"#,
+        );
+
+        assert_serialized_content(&request, "CreateItem", &expected);
+    }
 
     #[test]
     fn test_deserialize_create_item_response() {

--- a/ews/src/types/find_item.rs
+++ b/ews/src/types/find_item.rs
@@ -84,7 +84,7 @@ pub struct RootFolder {
 mod tests {
     use crate::{
         test_utils::{assert_deserialized_content, assert_serialized_content, minify_xml},
-        BasePoint, BaseShape, Groups, ItemId, Items, Message, RealItem, ResponseClass,
+        BasePoint, BaseShape, Groups, ItemId, Items, Mailbox, Message, RealItem, ResponseClass,
         ResponseMessages,
     };
 
@@ -98,10 +98,7 @@ mod tests {
                 base_shape: BaseShape::IdOnly,
                 ..Default::default()
             },
-            parent_folder_ids: vec![BaseFolderId::DistinguishedFolderId {
-                id: "deleteditems".to_string(),
-                change_key: None,
-            }],
+            parent_folder_ids: vec![BaseFolderId::new_distinguished("deleteditems")],
             view: Some(View::IndexedPageItemView {
                 max_entries_returned: Some(6),
                 offset: 0,
@@ -117,7 +114,7 @@ mod tests {
               </ItemShape>
               <IndexedPageItemView MaxEntriesReturned="6" BasePoint="Beginning" Offset="0"/>
               <ParentFolderIds>
-                <t:DistinguishedFolderId Id="deleteditems"/>
+                <t:DistinguishedFolderId Id="deleteditems"></t:DistinguishedFolderId>
               </ParentFolderIds>
             </FindItem>"#,
         );
@@ -133,10 +130,7 @@ mod tests {
                 base_shape: BaseShape::IdOnly,
                 ..Default::default()
             },
-            parent_folder_ids: vec![BaseFolderId::DistinguishedFolderId {
-                id: "inbox".to_string(),
-                change_key: None,
-            }],
+            parent_folder_ids: vec![BaseFolderId::new_distinguished("inbox")],
             view: Some(View::FractionalPageItemView {
                 max_entries_returned: Some(12),
                 numerator: 2,
@@ -152,7 +146,7 @@ mod tests {
               </ItemShape>
               <FractionalPageItemView MaxEntriesReturned="12" Numerator="2" Denominator="3"/>
               <ParentFolderIds>
-                <t:DistinguishedFolderId Id="inbox"/>
+                <t:DistinguishedFolderId Id="inbox"></t:DistinguishedFolderId>
               </ParentFolderIds>
             </FindItem>"#,
         );
@@ -167,10 +161,7 @@ mod tests {
                 base_shape: BaseShape::IdOnly,
                 ..Default::default()
             },
-            parent_folder_ids: vec![BaseFolderId::DistinguishedFolderId {
-                id: "calendar".to_string(),
-                change_key: None,
-            }],
+            parent_folder_ids: vec![BaseFolderId::new_distinguished("calendar")],
             view: Some(View::CalendarView {
                 max_entries_returned: Some(2),
                 start_date: "2006-05-18T00:00:00-08:00".to_string(),
@@ -186,7 +177,49 @@ mod tests {
               </ItemShape>
               <CalendarView MaxEntriesReturned="2" StartDate="2006-05-18T00:00:00-08:00" EndDate="2006-05-19T00:00:00-08:00"/>
               <ParentFolderIds>
-                <t:DistinguishedFolderId Id="calendar"/>
+                <t:DistinguishedFolderId Id="calendar"></t:DistinguishedFolderId>
+              </ParentFolderIds>
+            </FindItem>"#,
+        );
+
+        assert_serialized_content(&find_item, "FindItem", &expected);
+    }
+
+    #[test]
+    fn test_serialize_find_item_calendar_view_with_mailbox() {
+        let find_item = FindItem {
+            traversal: Traversal::Shallow,
+            item_shape: ItemShape {
+                base_shape: BaseShape::IdOnly,
+                ..Default::default()
+            },
+            parent_folder_ids: vec![BaseFolderId::new_distinguished_in_mailbox(
+                "calendar",
+                Mailbox {
+                    email_address: Some("room@example.com".to_string()),
+                    ..Default::default()
+                },
+            )],
+            view: Some(View::CalendarView {
+                max_entries_returned: Some(2),
+                start_date: "2006-05-18T00:00:00-08:00".to_string(),
+                end_date: "2006-05-19T00:00:00-08:00".to_string(),
+            }),
+        };
+
+        let expected = minify_xml(
+            r#"
+            <FindItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" Traversal="Shallow">
+              <ItemShape>
+                <t:BaseShape>IdOnly</t:BaseShape>
+              </ItemShape>
+              <CalendarView MaxEntriesReturned="2" StartDate="2006-05-18T00:00:00-08:00" EndDate="2006-05-19T00:00:00-08:00"/>
+              <ParentFolderIds>
+                <t:DistinguishedFolderId Id="calendar">
+                  <t:Mailbox>
+                    <t:EmailAddress>room@example.com</t:EmailAddress>
+                  </t:Mailbox>
+                </t:DistinguishedFolderId>
               </ParentFolderIds>
             </FindItem>"#,
         );
@@ -202,10 +235,7 @@ mod tests {
                 base_shape: BaseShape::IdOnly,
                 ..Default::default()
             },
-            parent_folder_ids: vec![BaseFolderId::DistinguishedFolderId {
-                id: "contacts".to_string(),
-                change_key: None,
-            }],
+            parent_folder_ids: vec![BaseFolderId::new_distinguished("contacts")],
             view: Some(View::ContactsView {
                 max_entries_returned: Some(3),
                 initial_name: Some("Kelly Rollin".to_string()),
@@ -221,7 +251,7 @@ mod tests {
               </ItemShape>
               <ContactsView MaxEntriesReturned="3" InitialName="Kelly Rollin"/>
               <ParentFolderIds>
-                <t:DistinguishedFolderId Id="contacts"/>
+                <t:DistinguishedFolderId Id="contacts"></t:DistinguishedFolderId>
               </ParentFolderIds>
             </FindItem>"#,
         );

--- a/ews/src/types/move_folder.rs
+++ b/ews/src/types/move_folder.rs
@@ -31,10 +31,7 @@ mod test {
     fn test_serialize_move_folder() {
         let move_folder = MoveFolder {
             inner: CopyMoveFolderData {
-                to_folder_id: BaseFolderId::DistinguishedFolderId {
-                    id: "junkemail".to_string(),
-                    change_key: None,
-                },
+                to_folder_id: BaseFolderId::new_distinguished("junkemail"),
                 folder_ids: vec![BaseFolderId::FolderId {
                     id: "AScAc".to_string(),
                     change_key: None,
@@ -46,7 +43,7 @@ mod test {
             r#"
             <MoveFolder xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
               <ToFolderId>
-                <t:DistinguishedFolderId Id="junkemail"/>
+                <t:DistinguishedFolderId Id="junkemail"></t:DistinguishedFolderId>
               </ToFolderId>
               <FolderIds>
                 <t:FolderId Id="AScAc"/>

--- a/ews/src/types/move_item.rs
+++ b/ews/src/types/move_item.rs
@@ -35,10 +35,7 @@ mod test {
     fn test_serialize_move_item() {
         let move_item = MoveItem {
             inner: CopyMoveItemData {
-                to_folder_id: BaseFolderId::DistinguishedFolderId {
-                    id: "drafts".to_string(),
-                    change_key: None,
-                },
+                to_folder_id: BaseFolderId::new_distinguished("drafts"),
                 item_ids: vec![BaseItemId::ItemId {
                     id: "AAAtAEF/swbAAA=".to_string(),
                     change_key: Some("EwAAABYA/s4b".to_string()),
@@ -51,7 +48,7 @@ mod test {
             r#"
             <MoveItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
               <ToFolderId>
-                <t:DistinguishedFolderId Id="drafts"/>
+                <t:DistinguishedFolderId Id="drafts"></t:DistinguishedFolderId>
               </ToFolderId>
               <ItemIds>
                 <t:ItemId Id="AAAtAEF/swbAAA=" ChangeKey="EwAAABYA/s4b"/>

--- a/ews/src/types/update_item.rs
+++ b/ews/src/types/update_item.rs
@@ -6,7 +6,9 @@ use ews_proc_macros::operation_response;
 use serde::Deserialize;
 use xml_struct::XmlSerialize;
 
-use crate::types::common::{BaseItemId, Message, MessageDisposition, PathToElement};
+use crate::types::common::{
+    BaseItemId, Message, MessageDisposition, PathToElement, SendMeetingInvitationsOrCancellations,
+};
 use crate::{Items, MESSAGES_NS_URI};
 
 /// A request to update properties of one or more Exchange items.
@@ -34,6 +36,15 @@ pub struct UpdateItem {
     /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/updateitem#conflictresolution-attribute>
     #[xml_struct(attribute)]
     pub conflict_resolution: Option<ConflictResolution>,
+
+    /// Whether/how meeting invitations or cancellations are sent to
+    /// attendees.
+    ///
+    /// Required when updating calendar items, otherwise it has no effect.
+    ///
+    /// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/updateitem#sendmeetinginvitationsorcancellations-attribute>
+    #[xml_struct(attribute)]
+    pub send_meeting_invitations_or_cancellations: Option<SendMeetingInvitationsOrCancellations>,
 
     /// A list of items and their corresponding updates.
     ///
@@ -111,4 +122,60 @@ pub enum ItemChangeDescription {
         #[xml_struct(ns_prefix = "t")]
         message: Message,
     },
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        test_utils::{assert_serialized_content, minify_xml},
+        BaseItemId, MessageDisposition, PathToElement, SendMeetingInvitationsOrCancellations,
+    };
+
+    use super::{ItemChange, ItemChangeDescription, ItemChangeInner, UpdateItem, Updates};
+
+    #[test]
+    fn test_serialize_update_item_send_meeting_invitations_or_cancellations() {
+        let request = UpdateItem {
+            message_disposition: MessageDisposition::SaveOnly,
+            conflict_resolution: None,
+            send_meeting_invitations_or_cancellations: Some(
+                SendMeetingInvitationsOrCancellations::SendToNone,
+            ),
+            item_changes: vec![ItemChange {
+                item_change: ItemChangeInner {
+                    item_id: BaseItemId::ItemId {
+                        id: "id".to_string(),
+                        change_key: None,
+                    },
+                    updates: Updates {
+                        inner: vec![ItemChangeDescription::SetItemField {
+                            field_uri: PathToElement::FieldURI {
+                                field_URI: "calendar:End".to_string(),
+                            },
+                            message: Default::default(),
+                        }],
+                    },
+                },
+            }],
+        };
+
+        let expected = minify_xml(
+            r#"
+            <UpdateItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" MessageDisposition="SaveOnly" SendMeetingInvitationsOrCancellations="SendToNone">
+              <ItemChanges>
+                <t:ItemChange>
+                  <t:ItemId Id="id"/>
+                  <t:Updates>
+                    <t:SetItemField>
+                      <t:FieldURI FieldURI="calendar:End"/>
+                      <t:Message></t:Message>
+                    </t:SetItemField>
+                  </t:Updates>
+                </t:ItemChange>
+              </ItemChanges>
+            </UpdateItem>"#,
+        );
+
+        assert_serialized_content(&request, "UpdateItem", &expected);
+    }
 }

--- a/ews/src/types/update_item.rs
+++ b/ews/src/types/update_item.rs
@@ -107,8 +107,259 @@ pub enum ItemChangeDescription {
         #[xml_struct(flatten, ns_prefix = "t")]
         field_uri: PathToElement,
 
-        /// The new value of the specified field.
-        #[xml_struct(ns_prefix = "t")]
-        message: Message,
+        /// The new value of the specified field, wrapped in an element
+        /// identifying the type of the item being updated.
+        #[xml_struct(flatten)]
+        value: ItemChangeFieldValue,
     },
+}
+
+impl ItemChangeDescription {
+    /// Creates a [`SetItemField`] update for a [`Message`] item.
+    ///
+    /// [`SetItemField`]: Self::SetItemField
+    pub fn new_message_field(field_uri: impl Into<String>, message: Message) -> Self {
+        ItemChangeDescription::SetItemField {
+            field_uri: PathToElement::new_field_uri(field_uri),
+            value: ItemChangeFieldValue::Message(message),
+        }
+    }
+
+    /// Creates a [`SetItemField`] update for a calendar item.
+    ///
+    /// [`SetItemField`]: Self::SetItemField
+    pub fn new_calendar_item_field(field_uri: impl Into<String>, calendar_item: Message) -> Self {
+        ItemChangeDescription::SetItemField {
+            field_uri: PathToElement::new_field_uri(field_uri),
+            value: ItemChangeFieldValue::CalendarItem(calendar_item),
+        }
+    }
+}
+
+/// The new value of a field being set via [`ItemChangeDescription::SetItemField`].
+///
+/// EWS requires this value to be wrapped in an element matching the type of
+/// the item being updated (e.g. `CalendarItem` for a calendar item), rather
+/// than always using `Message`; the server rejects a request for a calendar
+/// item's field wrapped in `Message` with `ErrorIncorrectUpdatePropertyCount`.
+///
+/// See <https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/setitemfield>
+#[derive(Clone, Debug, XmlSerialize)]
+#[xml_struct(variant_ns_prefix = "t")]
+pub enum ItemChangeFieldValue {
+    Message(Message),
+    CalendarItem(Message),
+}
+
+#[cfg(test)]
+mod test {
+    use quick_xml::{events::Event, Reader, Writer};
+    use time::OffsetDateTime;
+    use xml_struct::XmlSerialize;
+
+    use crate::{
+        test_utils::{assert_serialized_content, minify_xml},
+        BaseItemId, DateTime, Message, MessageDisposition,
+    };
+
+    use super::{ItemChange, ItemChangeDescription, ItemChangeInner, UpdateItem, Updates};
+
+    fn update_item_with_updates(updates: Updates) -> UpdateItem {
+        UpdateItem {
+            message_disposition: MessageDisposition::SaveOnly,
+            conflict_resolution: None,
+            item_changes: vec![ItemChange {
+                item_change: ItemChangeInner {
+                    item_id: BaseItemId::ItemId {
+                        id: "id".to_string(),
+                        change_key: None,
+                    },
+                    updates,
+                },
+            }],
+        }
+    }
+
+    fn update_item_with_change(change: ItemChangeDescription) -> UpdateItem {
+        update_item_with_updates(Updates {
+            inner: vec![change],
+        })
+    }
+
+    /// Counts the number of direct child elements of the first element named
+    /// `parent_tag` found in `xml`.
+    ///
+    /// Used to assert, independently of the exact XML shape, that a
+    /// `SetItemField` change wraps exactly one property, per EWS's
+    /// requirement (violating it produces
+    /// `ErrorIncorrectUpdatePropertyCount`).
+    fn count_direct_children(xml: &str, parent_tag: &str) -> usize {
+        let mut reader = Reader::from_str(xml);
+        let mut depth: i32 = -1;
+        let mut parent_depth = None;
+        let mut count = 0;
+
+        loop {
+            match reader.read_event().unwrap() {
+                Event::Start(e) => {
+                    depth += 1;
+
+                    if parent_depth.is_none() && e.name().as_ref() == parent_tag.as_bytes() {
+                        parent_depth = Some(depth);
+                    } else if parent_depth == Some(depth - 1) {
+                        count += 1;
+                    }
+                }
+                Event::Empty(e) => {
+                    if parent_depth == Some(depth) {
+                        count += 1;
+                    } else if parent_depth.is_none() && e.name().as_ref() == parent_tag.as_bytes() {
+                        // A self-closing `parent_tag` has no children.
+                        return 0;
+                    }
+                }
+                Event::End(_) => {
+                    if parent_depth == Some(depth) {
+                        return count;
+                    }
+
+                    depth -= 1;
+                }
+                Event::Eof => panic!("did not find element {parent_tag} in {xml}"),
+                _ => {}
+            }
+        }
+    }
+
+    #[test]
+    fn test_serialize_set_item_field_message() {
+        let request = update_item_with_change(ItemChangeDescription::new_message_field(
+            "calendar:End",
+            Message::default(),
+        ));
+
+        let expected = minify_xml(
+            r#"
+            <UpdateItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" MessageDisposition="SaveOnly">
+              <ItemChanges>
+                <t:ItemChange>
+                  <t:ItemId Id="id"/>
+                  <t:Updates>
+                    <t:SetItemField>
+                      <t:FieldURI FieldURI="calendar:End"/>
+                      <t:Message></t:Message>
+                    </t:SetItemField>
+                  </t:Updates>
+                </t:ItemChange>
+              </ItemChanges>
+            </UpdateItem>"#,
+        );
+
+        assert_serialized_content(&request, "UpdateItem", &expected);
+    }
+
+    #[test]
+    fn test_serialize_set_item_field_calendar_item() {
+        let request = update_item_with_change(ItemChangeDescription::new_calendar_item_field(
+            "calendar:End",
+            Message::default(),
+        ));
+
+        let expected = minify_xml(
+            r#"
+            <UpdateItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" MessageDisposition="SaveOnly">
+              <ItemChanges>
+                <t:ItemChange>
+                  <t:ItemId Id="id"/>
+                  <t:Updates>
+                    <t:SetItemField>
+                      <t:FieldURI FieldURI="calendar:End"/>
+                      <t:CalendarItem></t:CalendarItem>
+                    </t:SetItemField>
+                  </t:Updates>
+                </t:ItemChange>
+              </ItemChanges>
+            </UpdateItem>"#,
+        );
+
+        assert_serialized_content(&request, "UpdateItem", &expected);
+    }
+
+    /// Guards the EWS invariant that a `SetItemField` change may wrap only
+    /// one changed property (violating it produces
+    /// `ErrorIncorrectUpdatePropertyCount`).
+    #[test]
+    fn test_new_calendar_item_field_wraps_exactly_one_property() {
+        let change = ItemChangeDescription::new_calendar_item_field(
+            "calendar:End",
+            Message {
+                end: Some(DateTime(OffsetDateTime::UNIX_EPOCH)),
+                ..Default::default()
+            },
+        );
+
+        let mut writer: Writer<Vec<u8>> = Writer::new(Vec::new());
+        change
+            .serialize_as_element(&mut writer, "ItemChangeDescription")
+            .unwrap();
+        let xml = String::from_utf8(writer.into_inner()).unwrap();
+
+        assert_eq!(
+            count_direct_children(&xml, "t:CalendarItem"),
+            1,
+            "SetItemField must wrap exactly one property, got: {xml}"
+        );
+    }
+
+    #[test]
+    fn test_serialize_updates_with_multiple_set_item_field_calendar_item_changes() {
+        let request = update_item_with_updates(Updates {
+            inner: vec![
+                ItemChangeDescription::new_calendar_item_field(
+                    "calendar:End",
+                    Message {
+                        end: Some(DateTime(OffsetDateTime::UNIX_EPOCH)),
+                        ..Default::default()
+                    },
+                ),
+                ItemChangeDescription::new_calendar_item_field(
+                    "calendar:Location",
+                    Message {
+                        location: Some("Room 1".to_string()),
+                        ..Default::default()
+                    },
+                ),
+            ],
+        });
+
+        let expected = minify_xml(
+            r#"
+            <UpdateItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" MessageDisposition="SaveOnly">
+              <ItemChanges>
+                <t:ItemChange>
+                  <t:ItemId Id="id"/>
+                  <t:Updates>
+                    <t:SetItemField>
+                      <t:FieldURI FieldURI="calendar:End"/>
+                      <t:CalendarItem><t:End>__END_PLACEHOLDER__</t:End></t:CalendarItem>
+                    </t:SetItemField>
+                    <t:SetItemField>
+                      <t:FieldURI FieldURI="calendar:Location"/>
+                      <t:CalendarItem><t:Location>Room 1</t:Location></t:CalendarItem>
+                    </t:SetItemField>
+                  </t:Updates>
+                </t:ItemChange>
+              </ItemChanges>
+            </UpdateItem>"#,
+        )
+        .replace(
+            "__END_PLACEHOLDER__",
+            &DateTime(OffsetDateTime::UNIX_EPOCH)
+                .0
+                .format(&time::format_description::well_known::Iso8601::DEFAULT)
+                .unwrap(),
+        );
+
+        assert_serialized_content(&request, "UpdateItem", &expected);
+    }
 }


### PR DESCRIPTION
This PR is based on #89  and #92 and introduces a breaking change to `ItemChangeDescription::SetItemField`.

Previously, `UpdateItem` always wrapped the updated value in a `<t:Message>` element. While this works for mail items, Exchange requires the wrapper element to match the type of the item being updated. As a result, updating calendar items failed with `ErrorIncorrectUpdatePropertyCount` because the value was wrapped in `<t:Message>` instead of `<t:CalendarItem>`.

To support different item types, the `message: Message` field of `SetItemField` has been replaced with a `value: ItemChangeFieldValue` field. This is a **breaking API change**.

The old code:

```rust
ItemChangeDescription::SetItemField {
    field_uri: PathToElement::FieldURI {
        field_URI: "calendar:End".to_string(),
    },
    message: ews::Message {
        end: Some(ews::DateTime(now)),
        ..Default::default()
    },
}
```

should be replaced with

```rust
ItemChangeDescription::new_calendar_item_field(
    "calendar:End",
    ews::Message {
        end: Some(ews::DateTime(now)),
        ..Default::default()
    },
)
```

In this example, we still pass `ews::Message` to `new_calendar_item_field`, which is a bit awkward. If PR #91 is accepted, this variant's payload (`ItemChangeFieldValue::CalendarItem`) could be swapped for `ews::CalendarItem`, resulting in a cleaner and more intuitive API.

Added `ItemChangeDescription::new_message_field` / `new_calendar_item_field` and `PathToElement::new_field_uri` as ergonomic constructors, so callers don't need to build `ItemChangeFieldValue` / `PathToElement` variants by hand.

Also added tests covering both wrapping cases (`Message` and `CalendarItem`), including a structural test asserting that a `SetItemField` change always carries exactly one property — violating that invariant is what causes `ErrorIncorrectUpdatePropertyCount` in the first place.
